### PR TITLE
feat: Set different in/out trade limit

### DIFF
--- a/contracts/interfaces/ITradingLimits.sol
+++ b/contracts/interfaces/ITradingLimits.sol
@@ -30,10 +30,10 @@ interface ITradingLimits {
   struct Config {
     uint32 timestep0;
     uint32 timestep1;
-    uint48 limit0In;
-    uint48 limit0Out;
-    uint48 limit1In;
-    uint48 limit1Out;
+    int48 limit0In;
+    int48 limit0Out;
+    int48 limit1In;
+    int48 limit1Out;
     int48 limitGlobal;
     uint8 flags;
   }

--- a/contracts/interfaces/ITradingLimits.sol
+++ b/contracts/interfaces/ITradingLimits.sol
@@ -30,10 +30,8 @@ interface ITradingLimits {
   struct Config {
     uint32 timestep0;
     uint32 timestep1;
-    // int48 limit0;
     uint48 limit0In;
     uint48 limit0Out;
-    // int48 limit1;
     uint48 limit1In;
     uint48 limit1Out;
     int48 limitGlobal;

--- a/contracts/interfaces/ITradingLimits.sol
+++ b/contracts/interfaces/ITradingLimits.sol
@@ -30,10 +30,10 @@ interface ITradingLimits {
   struct Config {
     uint32 timestep0;
     uint32 timestep1;
-    int48 limit0;
+    // int48 limit0;
     uint48 limit0In;
     uint48 limit0Out;
-    int48 limit1;
+    // int48 limit1;
     uint48 limit1In;
     uint48 limit1Out;
     int48 limitGlobal;

--- a/contracts/interfaces/ITradingLimits.sol
+++ b/contracts/interfaces/ITradingLimits.sol
@@ -31,7 +31,11 @@ interface ITradingLimits {
     uint32 timestep0;
     uint32 timestep1;
     int48 limit0;
+    uint48 limit0In;
+    uint48 limit0Out;
     int48 limit1;
+    uint48 limit1In;
+    uint48 limit1Out;
     int48 limitGlobal;
     uint8 flags;
   }

--- a/contracts/libraries/TradingLimits.sol
+++ b/contracts/libraries/TradingLimits.sol
@@ -3,7 +3,6 @@ pragma solidity 0.8.18;
 pragma experimental ABIEncoderV2;
 
 import { ITradingLimits } from "contracts/interfaces/ITradingLimits.sol";
-import "forge-std/console.sol";
 
 /**
  * @title TradingLimits
@@ -72,22 +71,6 @@ library TradingLimits {
    * @param config the trading limit Config to check against.
    */
   function verify(ITradingLimits.State memory self, ITradingLimits.Config memory config) internal pure {
-    // if ((config.flags & L0) > 0 && (-1 * config.limit0 > self.netflow0 || self.netflow0 > config.limit0)) {
-    //   revert("L0 Exceeded");
-    // }
-    // if ((config.flags & L1) > 0 && (-1 * config.limit1 > self.netflow1 || self.netflow1 > config.limit1)) {
-    //   revert("L1 Exceeded");
-    // }
-    // if ((-1 * config.limit0) != -1 * int48(config.limit0Out)) {
-    //   console.log("(-1 * config.limit0) : ", (-1 * config.limit0));
-    //   console.log("-1 * int48(config.limit0Out) : ", -1 * int48(config.limit0Out));
-    //   revert("Whoops 1 ~~~");
-    // }
-    // if ((-1 * config.limit1) != -1 * int48(config.limit1Out)) {
-    //   console.log("(-1 * config.limit1) : ", (-1 * config.limit0));
-    //   console.log("-1 * int48(config.limit1Out): ", -1 * int48(config.limit0Out));
-    //   revert("Whoops 2 ~~~");
-    // }
     if ((config.flags & L0) > 0 && ((-1 * int48(config.limit0Out)) > self.netflow0 || self.netflow0 > int48(config.limit0In))) {
       revert("L0 Exceeded");
     }

--- a/contracts/libraries/TradingLimits.sol
+++ b/contracts/libraries/TradingLimits.sol
@@ -81,11 +81,21 @@ library TradingLimits {
    * @param config the trading limit Config to check against.
    */
   function verify(ITradingLimits.State memory self, ITradingLimits.Config memory config) internal pure {
-    if ((config.flags & L0) > 0 && ((-1 * int48(config.limit0Out)) > self.netflow0 || self.netflow0 > int48(config.limit0In))) {
-      revert("L0 Exceeded");
+    if ((config.flags & L0) > 0) {
+      if((-1 * int48(config.limit0Out)) > self.netflow0) {
+        revert("L0Out Exceeded");
+      }
+      if(self.netflow0 > int48(config.limit0In)) {
+        revert("L0In Exceeded");
+      }
     }
-    if ((config.flags & L1) > 0 && (-1 * int48(config.limit1Out) > self.netflow1 || self.netflow1 > int48(config.limit1In))) {
-      revert("L1 Exceeded");
+    if ((config.flags & L1) > 0) {
+      if(-1 * int48(config.limit1Out) > self.netflow1) {
+        revert("L1Out Exceeded");
+      }
+      if(self.netflow1 > int48(config.limit1In)) {
+        revert("L1In Exceeded");
+      }
     }
     if (
       (config.flags & LG) > 0 &&

--- a/contracts/libraries/TradingLimits.sol
+++ b/contracts/libraries/TradingLimits.sol
@@ -56,12 +56,22 @@ library TradingLimits {
     require(self.flags & L1 == 0 || self.flags & L0 != 0, "L1 without L0 not allowed");
     require(self.flags & L0 == 0 || self.timestep0 > 0, "timestep0 can't be zero if active");
     require(self.flags & L1 == 0 || self.timestep1 > 0, "timestep1 can't be zero if active");
-    require(self.flags & L0 == 0 || self.limit0 > 0, "limit0 can't be zero if active");
-    require(self.flags & L1 == 0 || self.limit1 > 0, "limit1 can't be zero if active");
+    // require(self.flags & L0 == 0 || self.limit0 > 0, "limit0 can't be zero if active");
+    require(self.flags & L0 == 0 || self.limit0In > 0, "limit0In can't be zero if active");
+    require(self.flags & L0 == 0 || self.limit0Out > 0, "limit0Out can't be zero if active");
+    // require(self.flags & L1 == 0 || self.limit1 > 0, "limit1 can't be zero if active");
+    require(self.flags & L1 == 0 || self.limit1In > 0, "limit1In can't be zero if active");
+    require(self.flags & L1 == 0 || self.limit1Out > 0, "limit1Out can't be zero if active");
     require(self.flags & LG == 0 || self.limitGlobal > 0, "limitGlobal can't be zero if active");
-    require(self.flags & (L0 | L1) != 3 || self.limit0 < self.limit1, "limit1 must be greater than limit0");
-    require(self.flags & (L1 | LG) != 6 || self.limit1 < self.limitGlobal, "limitGlobal must be greater than limit1");
-    require(self.flags & (L0 | LG) != 5 || self.limit0 < self.limitGlobal, "limitGlobal must be greater than limit0");
+    // require(self.flags & (L0 | L1) != 3 || self.limit0 < self.limit1, "limit1 must be greater than limit0");
+    require(self.flags & (L0 | L1) != 3 || self.limit0In < self.limit1In, "limit1In must be greater than limit0In");
+    require(self.flags & (L0 | L1) != 3 || self.limit0Out < self.limit1Out, "limit1Out must be greater than limit0Out");
+    // require(self.flags & (L1 | LG) != 6 || self.limit1 < self.limitGlobal, "limitGlobal must be greater than limit1");
+    // require(self.flags & (L0 | LG) != 5 || self.limit0 < self.limitGlobal, "limitGlobal must be greater than limit0");
+    require(self.flags & (L1 | LG) != 6 || int48(self.limit1In) < self.limitGlobal, "limitGlobal must be greater than limit1In");
+    require(self.flags & (L1 | LG) != 6 || int48(self.limit1Out) < self.limitGlobal, "limitGlobal must be greater than limit1Out");
+    require(self.flags & (L0 | LG) != 5 || int48(self.limit0In) < self.limitGlobal, "limitGlobal must be greater than limit0In");
+    require(self.flags & (L0 | LG) != 5 || int48(self.limit0Out) < self.limitGlobal, "limitGlobal must be greater than limit0Out");
   }
 
   /**

--- a/contracts/libraries/TradingLimits.sol
+++ b/contracts/libraries/TradingLimits.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.18;
 pragma experimental ABIEncoderV2;
 
 import { ITradingLimits } from "contracts/interfaces/ITradingLimits.sol";
+import "forge-std/console.sol";
 
 /**
  * @title TradingLimits
@@ -71,10 +72,26 @@ library TradingLimits {
    * @param config the trading limit Config to check against.
    */
   function verify(ITradingLimits.State memory self, ITradingLimits.Config memory config) internal pure {
-    if ((config.flags & L0) > 0 && (-1 * config.limit0 > self.netflow0 || self.netflow0 > config.limit0)) {
+    // if ((config.flags & L0) > 0 && (-1 * config.limit0 > self.netflow0 || self.netflow0 > config.limit0)) {
+    //   revert("L0 Exceeded");
+    // }
+    // if ((config.flags & L1) > 0 && (-1 * config.limit1 > self.netflow1 || self.netflow1 > config.limit1)) {
+    //   revert("L1 Exceeded");
+    // }
+    // if ((-1 * config.limit0) != -1 * int48(config.limit0Out)) {
+    //   console.log("(-1 * config.limit0) : ", (-1 * config.limit0));
+    //   console.log("-1 * int48(config.limit0Out) : ", -1 * int48(config.limit0Out));
+    //   revert("Whoops 1 ~~~");
+    // }
+    // if ((-1 * config.limit1) != -1 * int48(config.limit1Out)) {
+    //   console.log("(-1 * config.limit1) : ", (-1 * config.limit0));
+    //   console.log("-1 * int48(config.limit1Out): ", -1 * int48(config.limit0Out));
+    //   revert("Whoops 2 ~~~");
+    // }
+    if ((config.flags & L0) > 0 && ((-1 * int48(config.limit0Out)) > self.netflow0 || self.netflow0 > int48(config.limit0In))) {
       revert("L0 Exceeded");
     }
-    if ((config.flags & L1) > 0 && (-1 * config.limit1 > self.netflow1 || self.netflow1 > config.limit1)) {
+    if ((config.flags & L1) > 0 && (-1 * int48(config.limit1Out) > self.netflow1 || self.netflow1 > int48(config.limit1In))) {
       revert("L1 Exceeded");
     }
     if (

--- a/contracts/libraries/TradingLimits.sol
+++ b/contracts/libraries/TradingLimits.sol
@@ -68,10 +68,10 @@ library TradingLimits {
     require(self.flags & (L0 | L1) != 3 || self.limit0Out < self.limit1Out, "limit1Out must be greater than limit0Out");
     // require(self.flags & (L1 | LG) != 6 || self.limit1 < self.limitGlobal, "limitGlobal must be greater than limit1");
     // require(self.flags & (L0 | LG) != 5 || self.limit0 < self.limitGlobal, "limitGlobal must be greater than limit0");
-    require(self.flags & (L1 | LG) != 6 || int48(self.limit1In) < self.limitGlobal, "limitGlobal must be greater than limit1In");
-    require(self.flags & (L1 | LG) != 6 || int48(self.limit1Out) < self.limitGlobal, "limitGlobal must be greater than limit1Out");
-    require(self.flags & (L0 | LG) != 5 || int48(self.limit0In) < self.limitGlobal, "limitGlobal must be greater than limit0In");
-    require(self.flags & (L0 | LG) != 5 || int48(self.limit0Out) < self.limitGlobal, "limitGlobal must be greater than limit0Out");
+    require(self.flags & (L1 | LG) != 6 || self.limit1In < self.limitGlobal, "limitGlobal must be greater than limit1In");
+    require(self.flags & (L1 | LG) != 6 || self.limit1Out < self.limitGlobal, "limitGlobal must be greater than limit1Out");
+    require(self.flags & (L0 | LG) != 5 || self.limit0In < self.limitGlobal, "limitGlobal must be greater than limit0In");
+    require(self.flags & (L0 | LG) != 5 || self.limit0Out < self.limitGlobal, "limitGlobal must be greater than limit0Out");
   }
 
   /**
@@ -82,18 +82,18 @@ library TradingLimits {
    */
   function verify(ITradingLimits.State memory self, ITradingLimits.Config memory config) internal pure {
     if ((config.flags & L0) > 0) {
-      if((-1 * int48(config.limit0Out)) > self.netflow0) {
+      if((-1 * config.limit0Out) > self.netflow0) {
         revert("L0Out Exceeded");
       }
-      if(self.netflow0 > int48(config.limit0In)) {
+      if(self.netflow0 > config.limit0In) {
         revert("L0In Exceeded");
       }
     }
     if ((config.flags & L1) > 0) {
-      if(-1 * int48(config.limit1Out) > self.netflow1) {
+      if(-1 * config.limit1Out > self.netflow1) {
         revert("L1Out Exceeded");
       }
-      if(self.netflow1 > int48(config.limit1In)) {
+      if(self.netflow1 > config.limit1In) {
         revert("L1In Exceeded");
       }
     }

--- a/script/DeployGoodDollar.sol
+++ b/script/DeployGoodDollar.sol
@@ -144,6 +144,10 @@ contract DeployMento is Script {
       timestep1: 30 days, // Monthly timeframe
       limit0: 40000, // 40K weekly limit
       limit1: 80000, // 80K monthly limit
+      limit0In: 40000, // 40K weekly limit
+      limit0Out: 40000, // 40K weekly limit
+      limit1In: 80000, // 80K monthly limit
+      limit1Out: 80000, // 80K monthly limit
       limitGlobal: 0, // No global limit
       flags: 0x03 // enable 1+2 binary 011
     });

--- a/script/DeployGoodDollar.sol
+++ b/script/DeployGoodDollar.sol
@@ -142,8 +142,8 @@ contract DeployMento is Script {
     ITradingLimits.Config memory cusdLimits = ITradingLimits.Config({
       timestep0: 7 days, // Weekly timeframe
       timestep1: 30 days, // Monthly timeframe
-      limit0: 40000, // 40K weekly limit
-      limit1: 80000, // 80K monthly limit
+      // limit0: 40000, // 40K weekly limit
+      // limit1: 80000, // 80K monthly limit
       limit0In: 40000, // 40K weekly limit
       limit0Out: 40000, // 40K weekly limit
       limit1In: 80000, // 80K monthly limit

--- a/test/fork/BaseForkTest.sol
+++ b/test/fork/BaseForkTest.sol
@@ -129,7 +129,8 @@ abstract contract BaseForkTest is Test {
   }
 
   function transferCeloFromReserve(address to, uint256 amount) internal {
-    vm.prank(address(mentoReserve));
+    vm.startPrank(address(mentoReserve));
     IERC20(lookup("GoldToken")).transfer(to, amount);
+    vm.stopPrank();
   }
 }

--- a/test/fork/GoodDollar/GoodDollarBaseForkTest.sol
+++ b/test/fork/GoodDollar/GoodDollarBaseForkTest.sol
@@ -20,10 +20,12 @@ import { BaseForkTest } from "../BaseForkTest.sol";
 import { Broker } from "contracts/swap/Broker.sol";
 import { GoodDollarExchangeProvider } from "contracts/goodDollar/GoodDollarExchangeProvider.sol";
 import { GoodDollarExpansionController } from "contracts/goodDollar/GoodDollarExpansionController.sol";
+import { TradingLimitHelpers } from "../../fork/helpers/TradingLimitHelpers.sol";
 
 contract GoodDollarBaseForkTest is BaseForkTest {
   using FixidityLib for FixidityLib.Fraction;
   using TokenHelpers for *;
+  using TradingLimitHelpers for *;
 
   // Addresses
   address constant AVATAR_ADDRESS = 0x495d133B938596C9984d462F007B676bDc57eCEC;
@@ -199,12 +201,12 @@ contract GoodDollarBaseForkTest is BaseForkTest {
     ITradingLimits.Config memory config = ITradingLimits.Config({
       // No more than 5,000 cUSD outflow within 5 minutes
       timestep0: 300,
-      limit0: 5_000,
+      // limit0: 5_000,
       limit0In: 5_000,
       limit0Out: 5_000,
       // No more than 50,000 cUSD outflow within 1 day
       timestep1: 86_400,
-      limit1: 50_000,
+      // limit1: 50_000,
       limit1In: 50_000,
       limit1Out: 50_000,
       // No more than 100,000 cUSD outflow in total
@@ -243,7 +245,7 @@ contract GoodDollarBaseForkTest is BaseForkTest {
   function getTradingLimitsConfig(address tokenAddress) public view returns (ITradingLimits.Config memory config) {
     bytes32 limitId = getTradingLimitId(tokenAddress);
     ITradingLimits.Config memory _config;
-    (_config.timestep0, _config.timestep1, _config.limit0, _config.limit0In, _config.limit0Out, _config.limit1, _config.limit1In, _config.limit1Out, _config.limitGlobal, _config.flags) = Broker(
+    (_config.timestep0, _config.timestep1, _config.limit0In, _config.limit0Out, _config.limit1In, _config.limit1Out, _config.limitGlobal, _config.flags) = Broker(
       address(broker)
     ).tradingLimitsConfig(limitId);
 
@@ -274,8 +276,8 @@ contract GoodDollarBaseForkTest is BaseForkTest {
   function maxOutflow(address tokenAddress) internal view returns (int48) {
     ITradingLimits.Config memory config = getTradingLimitsConfig(tokenAddress);
     ITradingLimits.State memory state = getRefreshedTradingLimitsState(tokenAddress);
-    int48 maxOutflowL0 = config.limit0 + state.netflow0;
-    int48 maxOutflowL1 = config.limit1 + state.netflow1;
+    int48 maxOutflowL0 = state.getLimit0FromNetflow0(config) + state.netflow0;
+    int48 maxOutflowL1 = state.getLimit1FromNetflow1(config) + state.netflow1;
     int48 maxOutflowLG = config.limitGlobal + state.netflowGlobal;
 
     if (config.flags == L0 | L1 | LG) {

--- a/test/fork/GoodDollar/GoodDollarBaseForkTest.sol
+++ b/test/fork/GoodDollar/GoodDollarBaseForkTest.sol
@@ -200,9 +200,13 @@ contract GoodDollarBaseForkTest is BaseForkTest {
       // No more than 5,000 cUSD outflow within 5 minutes
       timestep0: 300,
       limit0: 5_000,
+      limit0In: 5_000,
+      limit0Out: 5_000,
       // No more than 50,000 cUSD outflow within 1 day
       timestep1: 86_400,
       limit1: 50_000,
+      limit1In: 50_000,
+      limit1Out: 50_000,
       // No more than 100,000 cUSD outflow in total
       limitGlobal: 100_000,
       flags: 1 | 2 | 4 // L0 = 1, L1 = 2, LG = 4
@@ -239,7 +243,7 @@ contract GoodDollarBaseForkTest is BaseForkTest {
   function getTradingLimitsConfig(address tokenAddress) public view returns (ITradingLimits.Config memory config) {
     bytes32 limitId = getTradingLimitId(tokenAddress);
     ITradingLimits.Config memory _config;
-    (_config.timestep0, _config.timestep1, _config.limit0, _config.limit1, _config.limitGlobal, _config.flags) = Broker(
+    (_config.timestep0, _config.timestep1, _config.limit0, _config.limit0In, _config.limit0Out, _config.limit1, _config.limit1In, _config.limit1Out, _config.limitGlobal, _config.flags) = Broker(
       address(broker)
     ).tradingLimitsConfig(limitId);
 

--- a/test/fork/GoodDollar/TradingLimitsForkTest.sol
+++ b/test/fork/GoodDollar/TradingLimitsForkTest.sol
@@ -68,7 +68,7 @@ contract GoodDollarTradingLimitsForkTest is GoodDollarBaseForkTest {
     ITradingLimits.Config memory config = getTradingLimitsConfig(address(reserveToken));
 
     // Get the max amount we can swap in a single transaction before we hit L0
-    uint256 maxPerSwapInWei = uint256(config.limit0Out) * 1e18;
+    uint256 maxPerSwapInWei = uint48(config.limit0Out) * 1e18;
     uint256 inflowRequiredForAmountOut = goodDollarExchangeProvider.getAmountIn({
       exchangeId: exchangeId,
       tokenIn: address(goodDollarToken),
@@ -159,7 +159,7 @@ contract GoodDollarTradingLimitsForkTest is GoodDollarBaseForkTest {
     ITradingLimits.Config memory config = getTradingLimitsConfig(address(reserveToken));
 
     // Get the max amount we can swap in a single transaction before we hit L0
-    uint256 maxPerSwapInWei = uint256(config.limit0In) * 1e18;
+    uint256 maxPerSwapInWei = uint48(config.limit0In) * 1e18;
     deal({ token: address(reserveToken), to: trader, give: maxPerSwapInWei });
 
     vm.startPrank(trader);

--- a/test/fork/GoodDollar/TradingLimitsForkTest.sol
+++ b/test/fork/GoodDollar/TradingLimitsForkTest.sol
@@ -31,32 +31,32 @@ contract GoodDollarTradingLimitsForkTest is GoodDollarBaseForkTest {
 
   function test_tradingLimitsAreEnforced_reserveTokenOutflowLimit0() public {
     _swapUntilReserveTokenLimit0_onOutflow();
-    _swapGoodDollarForReserveToken(bytes(L0.revertReason()));
+    _swapGoodDollarForReserveToken(bytes(L0.revertReason(false)));
   }
 
   function test_tradingLimitsAreEnforced_reserveTokenOutflowLimit1() public {
     _swapUntilReserveTokenLimit1_onOutflow();
-    _swapGoodDollarForReserveToken(bytes(L1.revertReason()));
+    _swapGoodDollarForReserveToken(bytes(L1.revertReason(false)));
   }
 
   function test_tradingLimitsAreEnforced_reserveTokenOutflowLimitGlobal() public {
     _swapUntilReserveTokenGlobalLimit_onOutflow();
-    _swapGoodDollarForReserveToken(bytes(LG.revertReason()));
+    _swapGoodDollarForReserveToken(bytes(LG.revertReason(false)));
   }
 
   function test_tradingLimitsAreEnforced_reserveTokenInflowLimit0() public {
     _swapUntilReserveTokenLimit0_onInflow();
-    _swapReserveTokenForGoodDollar(bytes(L0.revertReason()));
+    _swapReserveTokenForGoodDollar(bytes(L0.revertReason(true)));
   }
 
   function test_tradingLimitsAreEnforced_reserveTokenInflowLimit1() public {
     _swapUntilReserveTokenLimit1_onInflow();
-    _swapReserveTokenForGoodDollar(bytes(L1.revertReason()));
+    _swapReserveTokenForGoodDollar(bytes(L1.revertReason(true)));
   }
 
   function test_tradingLimitsAreEnforced_reserveTokenInflowGlobalLimit() public {
     _swapUntilReserveTokenGlobalLimit_onInflow();
-    _swapReserveTokenForGoodDollar(bytes(LG.revertReason()));
+    _swapReserveTokenForGoodDollar(bytes(LG.revertReason(true)));
   }
 
   /**

--- a/test/fork/GoodDollar/TradingLimitsForkTest.sol
+++ b/test/fork/GoodDollar/TradingLimitsForkTest.sol
@@ -68,7 +68,7 @@ contract GoodDollarTradingLimitsForkTest is GoodDollarBaseForkTest {
     ITradingLimits.Config memory config = getTradingLimitsConfig(address(reserveToken));
 
     // Get the max amount we can swap in a single transaction before we hit L0
-    uint256 maxPerSwapInWei = uint48(config.limit0Out) * 1e18;
+    uint256 maxPerSwapInWei = uint256(uint48(config.limit0Out)) * 1e18;
     uint256 inflowRequiredForAmountOut = goodDollarExchangeProvider.getAmountIn({
       exchangeId: exchangeId,
       tokenIn: address(goodDollarToken),
@@ -159,7 +159,7 @@ contract GoodDollarTradingLimitsForkTest is GoodDollarBaseForkTest {
     ITradingLimits.Config memory config = getTradingLimitsConfig(address(reserveToken));
 
     // Get the max amount we can swap in a single transaction before we hit L0
-    uint256 maxPerSwapInWei = uint48(config.limit0In) * 1e18;
+    uint256 maxPerSwapInWei = uint256(uint48(config.limit0In)) * 1e18;
     deal({ token: address(reserveToken), to: trader, give: maxPerSwapInWei });
 
     vm.startPrank(trader);

--- a/test/fork/actions/SwapActions.sol
+++ b/test/fork/actions/SwapActions.sol
@@ -105,7 +105,7 @@ contract SwapActions is StdCheats {
      */
 
     ITradingLimits.Config memory limitConfig = ctx.tradingLimitsConfig(from);
-    console.log(unicode"🏷️ [%d] Swap until L0In=%d, L0Out=%d on inflow", block.timestamp, uint256(limitConfig.limit0In), uint256(limitConfig.limit0Out));
+    console.log(unicode"🏷️ [%d] Swap until L0In=%d, L0Out=%d on inflow", block.timestamp, uint48(limitConfig.limit0In), uint48(limitConfig.limit0Out));
     uint256 maxPossible;
     uint256 maxPossibleUntilLimit;
     do {
@@ -134,7 +134,7 @@ contract SwapActions is StdCheats {
      */
     ITradingLimits.Config memory limitConfig = ctx.tradingLimitsConfig(from);
     ITradingLimits.State memory limitState = ctx.refreshedTradingLimitsState(from);
-    console.log(unicode"🏷️ [%d] Swap until L1In=%d, L1Out=%d on inflow", block.timestamp, uint256(limitConfig.limit1In), uint256(limitConfig.limit1Out));
+    console.log(unicode"🏷️ [%d] Swap until L1In=%d, L1Out=%d on inflow", block.timestamp, uint48(limitConfig.limit1In), uint48(limitConfig.limit1Out));
     int48 maxPerSwap = limitState.getLimit0FromNetflow0(limitConfig);
     while (limitState.netflow1 + maxPerSwap <= limitState.getLimit1FromNetflow1(limitConfig)) {
       skip(limitConfig.timestep0 + 1);
@@ -199,7 +199,7 @@ contract SwapActions is StdCheats {
      */
 
     ITradingLimits.Config memory limitConfig = ctx.tradingLimitsConfig(to);
-    console.log(unicode"🏷️ [%d] Swap until L0In=%d, L0Out=%d on outflow", block.timestamp, uint256(limitConfig.limit0In), uint256(limitConfig.limit0Out));
+    console.log(unicode"🏷️ [%d] Swap until L0In=%d, L0Out=%d on outflow", block.timestamp, uint48(limitConfig.limit0In), uint48(limitConfig.limit0Out));
     uint256 maxPossible;
     uint256 maxPossibleUntilLimit;
     do {

--- a/test/fork/assertions/SwapAssertions.sol
+++ b/test/fork/assertions/SwapAssertions.sol
@@ -181,7 +181,7 @@ contract SwapAssertions is StdAssertions, Actions {
     if (limit != LG && ctx.atInflowLimit(from, LG)) {
       console.log(unicode"🚨 Cannot validate limit %s as LG is already reached.", limit.toString());
     } else {
-      assert_swapInFails(from, to, inflowRequiredUnits.toSubunits(from), limit.revertReason());
+      assert_swapInFails(from, to, inflowRequiredUnits.toSubunits(from), limit.revertReason(true));
     }
   }
 
@@ -214,7 +214,7 @@ contract SwapAssertions is StdAssertions, Actions {
     if (limit != LG && ctx.atOutflowLimit(from, LG)) {
       console.log(unicode"🚨 Cannot validate limit %s as LG is already reached.", limit.toString());
     } else {
-      assert_swapOutFails(from, to, outflowRequiredUnits.toSubunits(to), limit.revertReason());
+      assert_swapOutFails(from, to, outflowRequiredUnits.toSubunits(to), limit.revertReason(true));
     }
   }
 }

--- a/test/fork/helpers/LogHelpers.sol
+++ b/test/fork/helpers/LogHelpers.sol
@@ -56,7 +56,7 @@ library LogHelpers {
         "\tL0: %s%d/%d",
         state.netflow0 < 0 ? "-" : "",
         uint256(int256(state.netflow0 < 0 ? state.netflow0 * -1 : state.netflow0)),
-        uint256(int256(config.limit0))
+        uint256(int256(state.getLimit0FromNetflow0(config)))
       );
     }
     if (config.flags & L1 > 0) {
@@ -64,7 +64,7 @@ library LogHelpers {
         "\tL1: %s%d/%d",
         state.netflow1 < 0 ? "-" : "",
         uint256(int256(state.netflow1 < 0 ? state.netflow1 * -1 : state.netflow1)),
-        uint256(int256(config.limit1))
+        uint256(int256(state.getLimit1FromNetflow1(config)))
       );
     }
     if (config.flags & LG > 0) {

--- a/test/fork/helpers/TradingLimitHelpers.sol
+++ b/test/fork/helpers/TradingLimitHelpers.sol
@@ -231,10 +231,10 @@ library TradingLimitHelpers {
   }
 
   function getLimit0FromNetflow0(ITradingLimits.State memory state, ITradingLimits.Config memory config) internal pure returns (int48){
-    return state.netflow0 < 0 ? -int48(config.limit0Out) : int48(config.limit0In);
+    return state.netflow0 < 0 ? -config.limit0Out : config.limit0In;
   }
   function getLimit1FromNetflow1(ITradingLimits.State memory state, ITradingLimits.Config memory config) internal pure returns (int48){
-    return state.netflow1 < 0 ? -int48(config.limit1Out) : int48(config.limit1In);
+    return state.netflow1 < 0 ? -config.limit1Out : config.limit1In;
   }
 
   function abs(int48 x) internal pure returns (int48) {

--- a/test/fork/helpers/TradingLimitHelpers.sol
+++ b/test/fork/helpers/TradingLimitHelpers.sol
@@ -231,12 +231,12 @@ library TradingLimitHelpers {
   }
 
   function getLimit0FromNetflow0(ITradingLimits.State memory state, ITradingLimits.Config memory config) internal pure returns (int48){
-    return state.netflow0 < 0 ? -config.limit0Out : config.limit0In;
+    return state.netflow0 < 0 ? config.limit0Out : config.limit0In;
   }
   function getLimit1FromNetflow1(ITradingLimits.State memory state, ITradingLimits.Config memory config) internal pure returns (int48){
-    return state.netflow1 < 0 ? -config.limit1Out : config.limit1In;
+    return state.netflow1 < 0 ? config.limit1Out : config.limit1In;
   }
-
+  
   function abs(int48 x) internal pure returns (int48) {
       return x >= 0 ? x : -x;
   }

--- a/test/fork/helpers/TradingLimitHelpers.sol
+++ b/test/fork/helpers/TradingLimitHelpers.sol
@@ -110,9 +110,9 @@ library TradingLimitHelpers {
 
   function getLimit(ITradingLimits.Config memory config, uint8 limit) internal pure returns (uint256) {
     if (limit == L0) {
-      return uint256(config.limit0In > config.limit0Out ? config.limit0Out : config.limit0In);
+      return uint48(config.limit0In > config.limit0Out ? config.limit0Out : config.limit0In);
     } else if (limit == L1) {
-      return uint256(config.limit1In > config.limit1Out ? config.limit1Out : config.limit1In);
+      return uint48(config.limit1In > config.limit1Out ? config.limit1Out : config.limit1In);
     } else if (limit == LG) {
       return uint256(int256(config.limitGlobal));
     } else {

--- a/test/fork/helpers/TradingLimitHelpers.sol
+++ b/test/fork/helpers/TradingLimitHelpers.sol
@@ -19,10 +19,10 @@ library TradingLimitHelpers {
     (
       limitConfig.timestep0,
       limitConfig.timestep1,
-      limitConfig.limit0,
+      // limitConfig.limit0,
       limitConfig.limit0In,
       limitConfig.limit0Out,
-      limitConfig.limit1,
+      // limitConfig.limit1,
       limitConfig.limit1In,
       limitConfig.limit1Out,
       limitConfig.limitGlobal,
@@ -39,10 +39,10 @@ library TradingLimitHelpers {
     (
       limitConfig.timestep0,
       limitConfig.timestep1,
-      limitConfig.limit0,
+      // limitConfig.limit0,
       limitConfig.limit0In,
       limitConfig.limit0Out,
-      limitConfig.limit1,
+      // limitConfig.limit1,
       limitConfig.limit1In,
       limitConfig.limit1Out,
       limitConfig.limitGlobal,
@@ -72,10 +72,10 @@ library TradingLimitHelpers {
     (
       limitConfig.timestep0,
       limitConfig.timestep1,
-      limitConfig.limit0,
+      // limitConfig.limit0,
       limitConfig.limit0In,
       limitConfig.limit0Out,
-      limitConfig.limit1,
+      // limitConfig.limit1,
       limitConfig.limit1In,
       limitConfig.limit1Out,
       limitConfig.limitGlobal,
@@ -116,9 +116,9 @@ library TradingLimitHelpers {
 
   function getLimit(ITradingLimits.Config memory config, uint8 limit) internal pure returns (uint256) {
     if (limit == L0) {
-      return uint256(int256(config.limit0));
+      return uint256(config.limit0In > config.limit0Out ? config.limit0Out : config.limit0In);
     } else if (limit == L1) {
-      return uint256(int256(config.limit1));
+      return uint256(config.limit1In > config.limit1Out ? config.limit1Out : config.limit1In);
     } else if (limit == LG) {
       return uint256(int256(config.limitGlobal));
     } else {
@@ -198,8 +198,8 @@ library TradingLimitHelpers {
   function maxInflow(ExchangeForkTest ctx, address from) internal view returns (int48) {
     ITradingLimits.Config memory limitConfig = tradingLimitsConfig(ctx, from);
     ITradingLimits.State memory limitState = refreshedTradingLimitsState(ctx, from);
-    int48 maxInflowL0 = limitConfig.limit0 - limitState.netflow0;
-    int48 maxInflowL1 = limitConfig.limit1 - limitState.netflow1;
+    int48 maxInflowL0 = getLimit0FromNetflow0(limitState, limitConfig) - limitState.netflow0;
+    int48 maxInflowL1 = getLimit1FromNetflow1(limitState, limitConfig) - limitState.netflow1;
     int48 maxInflowLG = limitConfig.limitGlobal - limitState.netflowGlobal;
 
     if (limitConfig.flags == L0 | L1 | LG) {
@@ -218,8 +218,9 @@ library TradingLimitHelpers {
   function maxOutflow(ExchangeForkTest ctx, address to) internal view returns (int48) {
     ITradingLimits.Config memory limitConfig = tradingLimitsConfig(ctx, to);
     ITradingLimits.State memory limitState = refreshedTradingLimitsState(ctx, to);
-    int48 maxOutflowL0 = limitConfig.limit0 + limitState.netflow0;
-    int48 maxOutflowL1 = limitConfig.limit1 + limitState.netflow1;
+    int48 maxOutflowL0 = getLimit0FromNetflow0(limitState, limitConfig) + limitState.netflow0;
+    int48 maxOutflowL1 = getLimit1FromNetflow1(limitState, limitConfig) + limitState.netflow1;
+
     int48 maxOutflowLG = limitConfig.limitGlobal + limitState.netflowGlobal;
 
     if (limitConfig.flags == L0 | L1 | LG) {
@@ -233,5 +234,16 @@ library TradingLimitHelpers {
     } else {
       revert("Unexpected limit config");
     }
+  }
+
+  function getLimit0FromNetflow0(ITradingLimits.State memory state, ITradingLimits.Config memory config) internal pure returns (int48){
+    return state.netflow0 < 0 ? -int48(config.limit0Out) : int48(config.limit0In);
+  }
+  function getLimit1FromNetflow1(ITradingLimits.State memory state, ITradingLimits.Config memory config) internal pure returns (int48){
+    return state.netflow1 < 0 ? -int48(config.limit1Out) : int48(config.limit1In);
+  }
+
+  function abs(int48 x) internal pure returns (int48) {
+      return x >= 0 ? x : -x;
   }
 }

--- a/test/fork/helpers/TradingLimitHelpers.sol
+++ b/test/fork/helpers/TradingLimitHelpers.sol
@@ -62,8 +62,6 @@ library TradingLimitHelpers {
 
   function tradingLimitsConfig(ExchangeForkTest ctx, address asset) public view returns (ITradingLimits.Config memory) {
     ITradingLimits.Config memory limitConfig;
-    bytes32 assetBytes32 = bytes32(uint256(uint160(asset)));
-    bytes32 limitId = ctx.exchangeId() ^ assetBytes32;
 
     (
       limitConfig.timestep0,
@@ -74,7 +72,7 @@ library TradingLimitHelpers {
       limitConfig.limit1Out,
       limitConfig.limitGlobal,
       limitConfig.flags
-    ) = Broker(address(ctx.broker())).tradingLimitsConfig(limitId);
+    ) = Broker(address(ctx.broker())).tradingLimitsConfig(ctx.exchangeId() ^ bytes32(uint256(uint160(asset))));
     return limitConfig;
   }
 
@@ -110,9 +108,9 @@ library TradingLimitHelpers {
 
   function getLimit(ITradingLimits.Config memory config, uint8 limit) internal pure returns (uint256) {
     if (limit == L0) {
-      return uint48(config.limit0In > config.limit0Out ? config.limit0Out : config.limit0In);
+      return uint256(uint48(config.limit0In > config.limit0Out ? config.limit0Out : config.limit0In));
     } else if (limit == L1) {
-      return uint48(config.limit1In > config.limit1Out ? config.limit1Out : config.limit1In);
+      return uint256(uint48(config.limit1In > config.limit1Out ? config.limit1Out : config.limit1In));
     } else if (limit == LG) {
       return uint256(int256(config.limitGlobal));
     } else {

--- a/test/fork/helpers/TradingLimitHelpers.sol
+++ b/test/fork/helpers/TradingLimitHelpers.sol
@@ -19,10 +19,8 @@ library TradingLimitHelpers {
     (
       limitConfig.timestep0,
       limitConfig.timestep1,
-      // limitConfig.limit0,
       limitConfig.limit0In,
       limitConfig.limit0Out,
-      // limitConfig.limit1,
       limitConfig.limit1In,
       limitConfig.limit1Out,
       limitConfig.limitGlobal,
@@ -39,10 +37,8 @@ library TradingLimitHelpers {
     (
       limitConfig.timestep0,
       limitConfig.timestep1,
-      // limitConfig.limit0,
       limitConfig.limit0In,
       limitConfig.limit0Out,
-      // limitConfig.limit1,
       limitConfig.limit1In,
       limitConfig.limit1Out,
       limitConfig.limitGlobal,
@@ -72,10 +68,8 @@ library TradingLimitHelpers {
     (
       limitConfig.timestep0,
       limitConfig.timestep1,
-      // limitConfig.limit0,
       limitConfig.limit0In,
       limitConfig.limit0Out,
-      // limitConfig.limit1,
       limitConfig.limit1In,
       limitConfig.limit1Out,
       limitConfig.limitGlobal,

--- a/test/fork/helpers/TradingLimitHelpers.sol
+++ b/test/fork/helpers/TradingLimitHelpers.sol
@@ -20,7 +20,11 @@ library TradingLimitHelpers {
       limitConfig.timestep0,
       limitConfig.timestep1,
       limitConfig.limit0,
+      limitConfig.limit0In,
+      limitConfig.limit0Out,
       limitConfig.limit1,
+      limitConfig.limit1In,
+      limitConfig.limit1Out,
       limitConfig.limitGlobal,
       limitConfig.flags
     ) = Broker(address(ctx.broker())).tradingLimitsConfig(limitId);
@@ -36,7 +40,11 @@ library TradingLimitHelpers {
       limitConfig.timestep0,
       limitConfig.timestep1,
       limitConfig.limit0,
+      limitConfig.limit0In,
+      limitConfig.limit0Out,
       limitConfig.limit1,
+      limitConfig.limit1In,
+      limitConfig.limit1Out,
       limitConfig.limitGlobal,
       limitConfig.flags
     ) = Broker(address(ctx.broker())).tradingLimitsConfig(limitId);
@@ -65,7 +73,11 @@ library TradingLimitHelpers {
       limitConfig.timestep0,
       limitConfig.timestep1,
       limitConfig.limit0,
+      limitConfig.limit0In,
+      limitConfig.limit0Out,
       limitConfig.limit1,
+      limitConfig.limit1In,
+      limitConfig.limit1Out,
       limitConfig.limitGlobal,
       limitConfig.flags
     ) = Broker(address(ctx.broker())).tradingLimitsConfig(limitId);

--- a/test/fork/helpers/TradingLimitHelpers.sol
+++ b/test/fork/helpers/TradingLimitHelpers.sol
@@ -130,11 +130,11 @@ library TradingLimitHelpers {
     }
   }
 
-  function revertReason(uint8 limit) internal pure returns (string memory) {
+  function revertReason(uint8 limit, bool isIn) internal pure returns (string memory) {
     if (limit == L0) {
-      return "L0 Exceeded";
+      return string(abi.encodePacked("L0", (isIn ? "In" : "Out"), " Exceeded"));
     } else if (limit == L1) {
-      return "L1 Exceeded";
+      return string(abi.encodePacked("L1", (isIn ? "In" : "Out"), " Exceeded"));
     } else if (limit == LG) {
       return "LG Exceeded";
     } else {

--- a/test/integration/protocol/ProtocolTest.sol
+++ b/test/integration/protocol/ProtocolTest.sol
@@ -458,7 +458,7 @@ contract ProtocolTest is Test, WithRegistry {
 
   function setUp_tradingLimits() internal {
     /* ========== Config Trading Limits =============== */
-    ITradingLimits.Config memory config = configL0L1LG(100, 10000, 10000, 10000, 1000, 100000, 100000, 100000, 1000000);
+    ITradingLimits.Config memory config = configL0L1LG(100, 10000, 10000, 1000, 100000, 100000, 1000000);
     broker.configureTradingLimit(pair_cUSD_CELO_ID, address(cUSDToken), config);
     broker.configureTradingLimit(pair_cEUR_CELO_ID, address(cEURToken), config);
     broker.configureTradingLimit(pair_cUSD_bridgedUSDC_ID, address(usdcToken), config);
@@ -469,21 +469,21 @@ contract ProtocolTest is Test, WithRegistry {
 
   function configL0L1LG(
     uint32 timestep0,
-    int48 limit0,
+    // int48 limit0,
     uint48 limit0In,
     uint48 limit0Out,
     uint32 timestep1,
-    int48 limit1,
+    // int48 limit1,
     uint48 limit1In,
     uint48 limit1Out,
     int48 limitGlobal
   ) internal pure returns (ITradingLimits.Config memory config) {
     config.timestep0 = timestep0;
-    config.limit0 = limit0;
+    // config.limit0 = limit0;
     config.limit0In = limit0In;
     config.limit0Out = limit0Out;
     config.timestep1 = timestep1;
-    config.limit1 = limit1;
+    // config.limit1 = limit1;
     config.limit1In = limit1In;
     config.limit1Out = limit1Out;
     config.limitGlobal = limitGlobal;

--- a/test/integration/protocol/ProtocolTest.sol
+++ b/test/integration/protocol/ProtocolTest.sol
@@ -470,12 +470,12 @@ contract ProtocolTest is Test, WithRegistry {
   function configL0L1LG(
     uint32 timestep0,
     // int48 limit0,
-    uint48 limit0In,
-    uint48 limit0Out,
+    int48 limit0In,
+    int48 limit0Out,
     uint32 timestep1,
     // int48 limit1,
-    uint48 limit1In,
-    uint48 limit1Out,
+    int48 limit1In,
+    int48 limit1Out,
     int48 limitGlobal
   ) internal pure returns (ITradingLimits.Config memory config) {
     config.timestep0 = timestep0;

--- a/test/integration/protocol/ProtocolTest.sol
+++ b/test/integration/protocol/ProtocolTest.sol
@@ -458,7 +458,7 @@ contract ProtocolTest is Test, WithRegistry {
 
   function setUp_tradingLimits() internal {
     /* ========== Config Trading Limits =============== */
-    ITradingLimits.Config memory config = configL0L1LG(100, 10000, 1000, 100000, 1000000);
+    ITradingLimits.Config memory config = configL0L1LG(100, 10000, 10000, 10000, 1000, 100000, 100000, 100000, 1000000);
     broker.configureTradingLimit(pair_cUSD_CELO_ID, address(cUSDToken), config);
     broker.configureTradingLimit(pair_cEUR_CELO_ID, address(cEURToken), config);
     broker.configureTradingLimit(pair_cUSD_bridgedUSDC_ID, address(usdcToken), config);
@@ -470,14 +470,22 @@ contract ProtocolTest is Test, WithRegistry {
   function configL0L1LG(
     uint32 timestep0,
     int48 limit0,
+    uint48 limit0In,
+    uint48 limit0Out,
     uint32 timestep1,
     int48 limit1,
+    uint48 limit1In,
+    uint48 limit1Out,
     int48 limitGlobal
   ) internal pure returns (ITradingLimits.Config memory config) {
     config.timestep0 = timestep0;
     config.limit0 = limit0;
+    config.limit0In = limit0In;
+    config.limit0Out = limit0Out;
     config.timestep1 = timestep1;
     config.limit1 = limit1;
+    config.limit1In = limit1In;
+    config.limit1Out = limit1Out;
     config.limitGlobal = limitGlobal;
     config.flags = 1 | 2 | 4; //L0, L1, and LG
   }

--- a/test/unit/libraries/TradingLimits.t.sol
+++ b/test/unit/libraries/TradingLimits.t.sol
@@ -19,14 +19,14 @@ contract TradingLimitsTest is Test {
 
   function configEmpty() internal pure returns (ITradingLimits.Config memory config) {}
 
-  function configL0(uint32 timestep0, uint48 limit0In, uint48 limit0Out) internal pure returns (ITradingLimits.Config memory config) {
+  function configL0(uint32 timestep0, int48 limit0In, int48 limit0Out) internal pure returns (ITradingLimits.Config memory config) {
     config.timestep0 = timestep0;
     config.limit0In = limit0In;
     config.limit0Out = limit0Out;
     config.flags = L0;
   }
 
-  function configL1(uint32 timestep1, uint48 limit1In, uint48 limit1Out) internal pure returns (ITradingLimits.Config memory config) {
+  function configL1(uint32 timestep1, int48 limit1In, int48 limit1Out) internal pure returns (ITradingLimits.Config memory config) {
     config.timestep1 = timestep1;
     config.limit1In = limit1In;
     config.limit1Out = limit1Out;
@@ -40,11 +40,11 @@ contract TradingLimitsTest is Test {
 
   function configL0L1(
     uint32 timestep0,
-    uint48 limit0In,
-    uint48 limit0Out,
+    int48 limit0In,
+    int48 limit0Out,
     uint32 timestep1,
-    uint48 limit1In,
-    uint48 limit1Out
+    int48 limit1In,
+    int48 limit1Out
   ) internal pure returns (ITradingLimits.Config memory config) {
     config.timestep0 = timestep0;
     config.limit0In = limit0In;
@@ -57,11 +57,11 @@ contract TradingLimitsTest is Test {
 
   function configL0L1LG(
     uint32 timestep0,
-    uint48 limit0In,
-    uint48 limit0Out,
+    int48 limit0In,
+    int48 limit0Out,
     uint32 timestep1,
-    uint48 limit1In,
-    uint48 limit1Out,
+    int48 limit1In,
+    int48 limit1Out,
     int48 limitGlobal
   ) internal pure returns (ITradingLimits.Config memory config) {
     config.timestep0 = timestep0;
@@ -76,8 +76,8 @@ contract TradingLimitsTest is Test {
 
   function configL1LG(
     uint32 timestep1,
-    uint48 limit1In,
-    uint48 limit1Out,
+    int48 limit1In,
+    int48 limit1Out,
     int48 limitGlobal
   ) internal pure returns (ITradingLimits.Config memory config) {
     config.timestep1 = timestep1;
@@ -89,8 +89,8 @@ contract TradingLimitsTest is Test {
 
   function configL0LG(
     uint32 timestep0,
-    uint48 limit0In,
-    uint48 limit0Out,
+    int48 limit0In,
+    int48 limit0Out,
     int48 limitGlobal
   ) internal pure returns (ITradingLimits.Config memory config) {
     config.timestep0 = timestep0;

--- a/test/unit/libraries/TradingLimits.t.sol
+++ b/test/unit/libraries/TradingLimits.t.sol
@@ -21,7 +21,7 @@ contract TradingLimitsTest is Test {
 
   function configL0(uint32 timestep0, int48 limit0, uint48 limit0In, uint48 limit0Out) internal pure returns (ITradingLimits.Config memory config) {
     config.timestep0 = timestep0;
-    config.limit0 = limit0;
+    // config.limit0 = limit0;
     config.limit0In = limit0In;
     config.limit0Out = limit0Out;
     config.flags = L0;
@@ -29,7 +29,7 @@ contract TradingLimitsTest is Test {
 
   function configL1(uint32 timestep1, int48 limit1, uint48 limit1In, uint48 limit1Out) internal pure returns (ITradingLimits.Config memory config) {
     config.timestep1 = timestep1;
-    config.limit1 = limit1;
+    // config.limit1 = limit1;
     config.limit1In = limit1In;
     config.limit1Out = limit1Out;
     config.flags = L1;
@@ -51,11 +51,11 @@ contract TradingLimitsTest is Test {
     uint48 limit1Out
   ) internal pure returns (ITradingLimits.Config memory config) {
     config.timestep0 = timestep0;
-    config.limit0 = limit0;
+    // config.limit0 = limit0;
     config.limit0In = limit0In;
     config.limit0Out = limit0Out;
     config.timestep1 = timestep1;
-    config.limit1 = limit1;
+    // config.limit1 = limit1;
     config.limit1In = limit1In;
     config.limit1Out = limit1Out;
     config.flags = L0 | L1;
@@ -73,11 +73,11 @@ contract TradingLimitsTest is Test {
     int48 limitGlobal
   ) internal pure returns (ITradingLimits.Config memory config) {
     config.timestep0 = timestep0;
-    config.limit0 = limit0;
+    // config.limit0 = limit0;
     config.limit0In = limit0In;
     config.limit0Out = limit0Out;
     config.timestep1 = timestep1;
-    config.limit1 = limit1;
+    // config.limit1 = limit1;
     config.limit1In = limit1In;
     config.limit1Out = limit1Out;
     config.limitGlobal = limitGlobal;
@@ -92,7 +92,7 @@ contract TradingLimitsTest is Test {
     int48 limitGlobal
   ) internal pure returns (ITradingLimits.Config memory config) {
     config.timestep1 = timestep1;
-    config.limit1 = limit1;
+    // config.limit1 = limit1;
     config.limit1In = limit1In;
     config.limit1Out = limit1Out;
     config.limitGlobal = limitGlobal;
@@ -107,7 +107,7 @@ contract TradingLimitsTest is Test {
     int48 limitGlobal
   ) internal pure returns (ITradingLimits.Config memory config) {
     config.timestep0 = timestep0;
-    config.limit0 = limit0;
+    // config.limit0 = limit0;
     config.limit0In = limit0In;
     config.limit0Out = limit0Out;
     config.limitGlobal = limitGlobal;
@@ -133,7 +133,7 @@ contract TradingLimitsTest is Test {
 
   function test_validate_withL0_withoutLimit0_isNotValid() public {
     ITradingLimits.Config memory config = configL0(100, 0, 0, 0);
-    vm.expectRevert(bytes("limit0 can't be zero if active"));
+    vm.expectRevert(bytes("limit0In can't be zero if active"));
     harness.validate(config);
   }
 
@@ -144,7 +144,7 @@ contract TradingLimitsTest is Test {
 
   function test_validate_withL1_withoutLimit1_isNotValid() public {
     ITradingLimits.Config memory config = configL0L1(100, 1000, 1000, 1000, 1000, 0, 0, 0);
-    vm.expectRevert(bytes("limit1 can't be zero if active"));
+    vm.expectRevert(bytes("limit1In can't be zero if active"));
     harness.validate(config);
   }
 
@@ -156,7 +156,7 @@ contract TradingLimitsTest is Test {
 
   function test_validate_withL0L1_withLimit0LargerLimit1_isNotValid() public {
     ITradingLimits.Config memory config = configL0L1(10000, 10000, 10000, 10000, 1000, 1000, 1000, 1000);
-    vm.expectRevert(bytes("limit1 must be greater than limit0"));
+    vm.expectRevert(bytes("limit1In must be greater than limit0In"));
     harness.validate(config);
   }
 
@@ -168,13 +168,13 @@ contract TradingLimitsTest is Test {
 
   function test_validate_withL0LG_withLimit0LargerLimitGlobal_isNotValid() public {
     ITradingLimits.Config memory config = configL0LG(10000, 10000, 10000, 10000, 1000);
-    vm.expectRevert(bytes("limitGlobal must be greater than limit0"));
+    vm.expectRevert(bytes("limitGlobal must be greater than limit0In"));
     harness.validate(config);
   }
 
   function test_validate_withL1LG_withLimit1LargerLimitGlobal_isNotValid() public {
     ITradingLimits.Config memory config = configL0L1LG(100, 1000, 1000, 1000, 10000, 10000, 10000, 10000, 1000);
-    vm.expectRevert(bytes("limitGlobal must be greater than limit1"));
+    vm.expectRevert(bytes("limitGlobal must be greater than limit1In"));
     harness.validate(config);
   }
 

--- a/test/unit/libraries/TradingLimits.t.sol
+++ b/test/unit/libraries/TradingLimits.t.sol
@@ -19,17 +19,15 @@ contract TradingLimitsTest is Test {
 
   function configEmpty() internal pure returns (ITradingLimits.Config memory config) {}
 
-  function configL0(uint32 timestep0, int48 limit0, uint48 limit0In, uint48 limit0Out) internal pure returns (ITradingLimits.Config memory config) {
+  function configL0(uint32 timestep0, uint48 limit0In, uint48 limit0Out) internal pure returns (ITradingLimits.Config memory config) {
     config.timestep0 = timestep0;
-    // config.limit0 = limit0;
     config.limit0In = limit0In;
     config.limit0Out = limit0Out;
     config.flags = L0;
   }
 
-  function configL1(uint32 timestep1, int48 limit1, uint48 limit1In, uint48 limit1Out) internal pure returns (ITradingLimits.Config memory config) {
+  function configL1(uint32 timestep1, uint48 limit1In, uint48 limit1Out) internal pure returns (ITradingLimits.Config memory config) {
     config.timestep1 = timestep1;
-    // config.limit1 = limit1;
     config.limit1In = limit1In;
     config.limit1Out = limit1Out;
     config.flags = L1;
@@ -42,20 +40,16 @@ contract TradingLimitsTest is Test {
 
   function configL0L1(
     uint32 timestep0,
-    int48 limit0,
     uint48 limit0In,
     uint48 limit0Out,
     uint32 timestep1,
-    int48 limit1,
     uint48 limit1In,
     uint48 limit1Out
   ) internal pure returns (ITradingLimits.Config memory config) {
     config.timestep0 = timestep0;
-    // config.limit0 = limit0;
     config.limit0In = limit0In;
     config.limit0Out = limit0Out;
     config.timestep1 = timestep1;
-    // config.limit1 = limit1;
     config.limit1In = limit1In;
     config.limit1Out = limit1Out;
     config.flags = L0 | L1;
@@ -63,21 +57,17 @@ contract TradingLimitsTest is Test {
 
   function configL0L1LG(
     uint32 timestep0,
-    int48 limit0,
     uint48 limit0In,
     uint48 limit0Out,
     uint32 timestep1,
-    int48 limit1,
     uint48 limit1In,
     uint48 limit1Out,
     int48 limitGlobal
   ) internal pure returns (ITradingLimits.Config memory config) {
     config.timestep0 = timestep0;
-    // config.limit0 = limit0;
     config.limit0In = limit0In;
     config.limit0Out = limit0Out;
     config.timestep1 = timestep1;
-    // config.limit1 = limit1;
     config.limit1In = limit1In;
     config.limit1Out = limit1Out;
     config.limitGlobal = limitGlobal;
@@ -86,13 +76,11 @@ contract TradingLimitsTest is Test {
 
   function configL1LG(
     uint32 timestep1,
-    int48 limit1,
     uint48 limit1In,
     uint48 limit1Out,
     int48 limitGlobal
   ) internal pure returns (ITradingLimits.Config memory config) {
     config.timestep1 = timestep1;
-    // config.limit1 = limit1;
     config.limit1In = limit1In;
     config.limit1Out = limit1Out;
     config.limitGlobal = limitGlobal;
@@ -101,13 +89,11 @@ contract TradingLimitsTest is Test {
 
   function configL0LG(
     uint32 timestep0,
-    int48 limit0,
     uint48 limit0In,
     uint48 limit0Out,
     int48 limitGlobal
   ) internal pure returns (ITradingLimits.Config memory config) {
     config.timestep0 = timestep0;
-    // config.limit0 = limit0;
     config.limit0In = limit0In;
     config.limit0Out = limit0Out;
     config.limitGlobal = limitGlobal;
@@ -121,70 +107,70 @@ contract TradingLimitsTest is Test {
   /* ==================== Config#validate ==================== */
 
   function test_validate_withL0_isValid() public view {
-    ITradingLimits.Config memory config = configL0(100, 1000, 1000, 1000);
+    ITradingLimits.Config memory config = configL0(100, 1000, 1000);
     harness.validate(config);
   }
 
   function test_validate_withL0_withoutTimestep_isNotValid() public {
-    ITradingLimits.Config memory config = configL0(0, 1000, 1000, 1000);
+    ITradingLimits.Config memory config = configL0(0, 1000, 1000);
     vm.expectRevert(bytes("timestep0 can't be zero if active"));
     harness.validate(config);
   }
 
   function test_validate_withL0_withoutLimit0_isNotValid() public {
-    ITradingLimits.Config memory config = configL0(100, 0, 0, 0);
+    ITradingLimits.Config memory config = configL0(100, 0, 0);
     vm.expectRevert(bytes("limit0In can't be zero if active"));
     harness.validate(config);
   }
 
   function test_validate_withL0L1_isValid() public view {
-    ITradingLimits.Config memory config = configL0L1(100, 1000, 1000, 1000, 1000, 10000, 10000, 10000);
+    ITradingLimits.Config memory config = configL0L1(100, 1000, 1000, 1000, 10000, 10000);
     harness.validate(config);
   }
 
   function test_validate_withL1_withoutLimit1_isNotValid() public {
-    ITradingLimits.Config memory config = configL0L1(100, 1000, 1000, 1000, 1000, 0, 0, 0);
+    ITradingLimits.Config memory config = configL0L1(100, 1000, 1000, 1000, 0, 0);
     vm.expectRevert(bytes("limit1In can't be zero if active"));
     harness.validate(config);
   }
 
   function test_validate_withL0L1_withoutTimestape_isNotValid() public {
-    ITradingLimits.Config memory config = configL0L1(0, 1000, 1000, 1000, 1000, 10000, 10000, 10000);
+    ITradingLimits.Config memory config = configL0L1(0, 1000, 1000, 1000, 10000, 10000);
     vm.expectRevert(bytes("timestep0 can't be zero if active"));
     harness.validate(config);
   }
 
   function test_validate_withL0L1_withLimit0LargerLimit1_isNotValid() public {
-    ITradingLimits.Config memory config = configL0L1(10000, 10000, 10000, 10000, 1000, 1000, 1000, 1000);
+    ITradingLimits.Config memory config = configL0L1(10000, 10000, 10000, 1000, 1000, 1000);
     vm.expectRevert(bytes("limit1In must be greater than limit0In"));
     harness.validate(config);
   }
 
   function test_validate_withLG_withoutLimitGlobal_isNotValid() public {
-    ITradingLimits.Config memory config = configL0L1LG(100, 1000, 1000, 1000, 1000, 10000, 10000, 10000, 0);
+    ITradingLimits.Config memory config = configL0L1LG(100, 1000, 1000, 1000, 10000, 10000, 0);
     vm.expectRevert(bytes("limitGlobal can't be zero if active"));
     harness.validate(config);
   }
 
   function test_validate_withL0LG_withLimit0LargerLimitGlobal_isNotValid() public {
-    ITradingLimits.Config memory config = configL0LG(10000, 10000, 10000, 10000, 1000);
+    ITradingLimits.Config memory config = configL0LG(10000, 10000, 10000, 1000);
     vm.expectRevert(bytes("limitGlobal must be greater than limit0In"));
     harness.validate(config);
   }
 
   function test_validate_withL1LG_withLimit1LargerLimitGlobal_isNotValid() public {
-    ITradingLimits.Config memory config = configL0L1LG(100, 1000, 1000, 1000, 10000, 10000, 10000, 10000, 1000);
+    ITradingLimits.Config memory config = configL0L1LG(100, 1000, 1000, 10000, 10000, 10000, 1000);
     vm.expectRevert(bytes("limitGlobal must be greater than limit1In"));
     harness.validate(config);
   }
 
   function test_validate_withL0L1LG_isValid() public view {
-    ITradingLimits.Config memory config = configL0L1LG(100, 1000, 1000, 1000, 1000, 10000, 10000, 10000, 100000);
+    ITradingLimits.Config memory config = configL0L1LG(100, 1000, 1000, 1000, 10000, 10000, 100000);
     harness.validate(config);
   }
 
   function test_configure_withL1LG_isNotValid() public {
-    ITradingLimits.Config memory config = configL1LG(1000, 10000, 10000, 10000, 100000);
+    ITradingLimits.Config memory config = configL1LG(1000, 10000, 10000, 100000);
     vm.expectRevert(bytes("L1 without L0 not allowed"));
     harness.validate(config);
   }
@@ -194,7 +180,7 @@ contract TradingLimitsTest is Test {
   function test_reset_clearsCheckpoints() public {
     state.lastUpdated0 = 123412412;
     state.lastUpdated1 = 123124412;
-    state = harness.reset(state, configL0(500, 1000, 1000, 1000));
+    state = harness.reset(state, configL0(500, 1000, 1000));
 
     assertEq(uint256(state.lastUpdated0), 0);
     assertEq(uint256(state.lastUpdated1), 0);
@@ -203,7 +189,7 @@ contract TradingLimitsTest is Test {
   function test_reset_resetsNetflowsOnDisabled() public {
     state.netflow1 = 12312;
     state.netflowGlobal = 12312;
-    state = harness.reset(state, configL0(500, 1000, 1000, 1000));
+    state = harness.reset(state, configL0(500, 1000, 1000));
 
     assertEq(state.netflow1, 0);
     assertEq(state.netflowGlobal, 0);
@@ -213,7 +199,7 @@ contract TradingLimitsTest is Test {
     state.netflow0 = 12312;
     state.netflow1 = 12312;
     state.netflowGlobal = 12312;
-    state = harness.reset(state, configL0LG(500, 1000, 1000, 1000, 100000));
+    state = harness.reset(state, configL0LG(500, 1000, 1000, 100000));
 
     assertEq(state.netflow0, 12312);
     assertEq(state.netflow1, 0);
@@ -229,36 +215,36 @@ contract TradingLimitsTest is Test {
 
   function test_verify_withL0_butNotMet() public {
     state.netflow0 = 500;
-    harness.verify(state, configL0(500, 1230, 1230, 1230));
+    harness.verify(state, configL0(500, 1230, 1230));
   }
 
   function test_verify_withL0_andMetPositively() public {
     state.netflow0 = 1231;
-    vm.expectRevert(bytes("L0 Exceeded"));
-    harness.verify(state, configL0(500, 1230, 1230, 1230));
+    vm.expectRevert(bytes("L0In Exceeded"));
+    harness.verify(state, configL0(500, 1230, 2000));
   }
 
   function test_verify_withL0_andMetNegatively() public {
     state.netflow0 = -1231;
-    vm.expectRevert(bytes("L0 Exceeded"));
-    harness.verify(state, configL0(500, 1230, 1230, 1230));
+    vm.expectRevert(bytes("L0Out Exceeded"));
+    harness.verify(state, configL0(500, 2000, 1230));
   }
 
   function test_verify_withL0L1_butNoneMet() public {
     state.netflow1 = 500;
-    harness.verify(state, configL0L1(50, 100, 100, 100, 500, 500, 500, 1230));
+    harness.verify(state, configL0L1(50, 100, 100, 500, 500, 1230));
   }
 
   function test_verify_withL0L1_andL1MetPositively() public {
     state.netflow1 = 1231;
-    vm.expectRevert(bytes("L1 Exceeded"));
-    harness.verify(state, configL0L1(50, 100, 100, 100, 500, 500, 500, 1230));
+    vm.expectRevert(bytes("L1In Exceeded"));
+    harness.verify(state, configL0L1(50, 100, 100, 500, 1230, 2000));
   }
 
   function test_verify_withL0L1_andL1MetNegatively() public {
     state.netflow1 = -1231;
-    vm.expectRevert(bytes("L1 Exceeded"));
-    harness.verify(state, configL0L1(50, 100, 100, 100, 500, 500, 500, 1230));
+    vm.expectRevert(bytes("L1Out Exceeded"));
+    harness.verify(state, configL0L1(50, 100, 100, 500, 2000, 1230));
   }
 
   function test_verify_withLG_butNoneMet() public {
@@ -288,27 +274,27 @@ contract TradingLimitsTest is Test {
   }
 
   function test_update_withZeroDeltaFlow_doesNotUpdate() public {
-    state = harness.update(state, configL0L1LG(300, 1000, 1000, 1000, 1 days, 10000, 10000, 10000, 1000000), 0, 18);
+    state = harness.update(state, configL0L1LG(300, 1000, 1000, 1 days, 10000, 10000, 1000000), 0, 18);
     assertEq(state.netflow0, 0);
     assertEq(state.netflow1, 0);
     assertEq(state.netflowGlobal, 0);
   }
 
   function test_update_withL0_updatesActive() public {
-    state = harness.update(state, configL0(500, 1000, 1000, 1000), 100 * 1e18, 18);
+    state = harness.update(state, configL0(500, 1000, 1000), 100 * 1e18, 18);
     assertEq(state.netflow0, 100);
     assertEq(state.netflowGlobal, 0);
   }
 
   function test_update_withL0L1_updatesActive() public {
-    state = harness.update(state, configL0L1(500, 1000, 1000, 1000, 5000, 500000, 500000, 500000), 100 * 1e18, 18);
+    state = harness.update(state, configL0L1(500, 1000, 1000, 5000, 500000, 500000), 100 * 1e18, 18);
     assertEq(state.netflow0, 100);
     assertEq(state.netflow1, 100);
     assertEq(state.netflowGlobal, 0);
   }
 
   function test_update_withL0LG_updatesActive() public {
-    state = harness.update(state, configL0LG(500, 1000, 1000, 1000, 500000), 100 * 1e18, 18);
+    state = harness.update(state, configL0LG(500, 1000, 1000, 500000), 100 * 1e18, 18);
     assertEq(state.netflow0, 100);
     assertEq(state.netflow1, 0);
     assertEq(state.netflowGlobal, 100);

--- a/test/unit/libraries/TradingLimits.t.sol
+++ b/test/unit/libraries/TradingLimits.t.sol
@@ -19,15 +19,19 @@ contract TradingLimitsTest is Test {
 
   function configEmpty() internal pure returns (ITradingLimits.Config memory config) {}
 
-  function configL0(uint32 timestep0, int48 limit0) internal pure returns (ITradingLimits.Config memory config) {
+  function configL0(uint32 timestep0, int48 limit0, uint48 limit0In, uint48 limit0Out) internal pure returns (ITradingLimits.Config memory config) {
     config.timestep0 = timestep0;
     config.limit0 = limit0;
+    config.limit0In = limit0In;
+    config.limit0Out = limit0Out;
     config.flags = L0;
   }
 
-  function configL1(uint32 timestep1, int48 limit1) internal pure returns (ITradingLimits.Config memory config) {
+  function configL1(uint32 timestep1, int48 limit1, uint48 limit1In, uint48 limit1Out) internal pure returns (ITradingLimits.Config memory config) {
     config.timestep1 = timestep1;
     config.limit1 = limit1;
+    config.limit1In = limit1In;
+    config.limit1Out = limit1Out;
     config.flags = L1;
   }
 
@@ -39,27 +43,43 @@ contract TradingLimitsTest is Test {
   function configL0L1(
     uint32 timestep0,
     int48 limit0,
+    uint48 limit0In,
+    uint48 limit0Out,
     uint32 timestep1,
-    int48 limit1
+    int48 limit1,
+    uint48 limit1In,
+    uint48 limit1Out
   ) internal pure returns (ITradingLimits.Config memory config) {
     config.timestep0 = timestep0;
     config.limit0 = limit0;
+    config.limit0In = limit0In;
+    config.limit0Out = limit0Out;
     config.timestep1 = timestep1;
     config.limit1 = limit1;
+    config.limit1In = limit1In;
+    config.limit1Out = limit1Out;
     config.flags = L0 | L1;
   }
 
   function configL0L1LG(
     uint32 timestep0,
     int48 limit0,
+    uint48 limit0In,
+    uint48 limit0Out,
     uint32 timestep1,
     int48 limit1,
+    uint48 limit1In,
+    uint48 limit1Out,
     int48 limitGlobal
   ) internal pure returns (ITradingLimits.Config memory config) {
     config.timestep0 = timestep0;
     config.limit0 = limit0;
+    config.limit0In = limit0In;
+    config.limit0Out = limit0Out;
     config.timestep1 = timestep1;
     config.limit1 = limit1;
+    config.limit1In = limit1In;
+    config.limit1Out = limit1Out;
     config.limitGlobal = limitGlobal;
     config.flags = L0 | L1 | LG;
   }
@@ -67,10 +87,14 @@ contract TradingLimitsTest is Test {
   function configL1LG(
     uint32 timestep1,
     int48 limit1,
+    uint48 limit1In,
+    uint48 limit1Out,
     int48 limitGlobal
   ) internal pure returns (ITradingLimits.Config memory config) {
     config.timestep1 = timestep1;
     config.limit1 = limit1;
+    config.limit1In = limit1In;
+    config.limit1Out = limit1Out;
     config.limitGlobal = limitGlobal;
     config.flags = L1 | LG;
   }
@@ -78,10 +102,14 @@ contract TradingLimitsTest is Test {
   function configL0LG(
     uint32 timestep0,
     int48 limit0,
+    uint48 limit0In,
+    uint48 limit0Out,
     int48 limitGlobal
   ) internal pure returns (ITradingLimits.Config memory config) {
     config.timestep0 = timestep0;
     config.limit0 = limit0;
+    config.limit0In = limit0In;
+    config.limit0Out = limit0Out;
     config.limitGlobal = limitGlobal;
     config.flags = L0 | LG;
   }
@@ -93,70 +121,70 @@ contract TradingLimitsTest is Test {
   /* ==================== Config#validate ==================== */
 
   function test_validate_withL0_isValid() public view {
-    ITradingLimits.Config memory config = configL0(100, 1000);
+    ITradingLimits.Config memory config = configL0(100, 1000, 1000, 1000);
     harness.validate(config);
   }
 
   function test_validate_withL0_withoutTimestep_isNotValid() public {
-    ITradingLimits.Config memory config = configL0(0, 1000);
+    ITradingLimits.Config memory config = configL0(0, 1000, 1000, 1000);
     vm.expectRevert(bytes("timestep0 can't be zero if active"));
     harness.validate(config);
   }
 
   function test_validate_withL0_withoutLimit0_isNotValid() public {
-    ITradingLimits.Config memory config = configL0(100, 0);
+    ITradingLimits.Config memory config = configL0(100, 0, 0, 0);
     vm.expectRevert(bytes("limit0 can't be zero if active"));
     harness.validate(config);
   }
 
   function test_validate_withL0L1_isValid() public view {
-    ITradingLimits.Config memory config = configL0L1(100, 1000, 1000, 10000);
+    ITradingLimits.Config memory config = configL0L1(100, 1000, 1000, 1000, 1000, 10000, 10000, 10000);
     harness.validate(config);
   }
 
   function test_validate_withL1_withoutLimit1_isNotValid() public {
-    ITradingLimits.Config memory config = configL0L1(100, 1000, 1000, 0);
+    ITradingLimits.Config memory config = configL0L1(100, 1000, 1000, 1000, 1000, 0, 0, 0);
     vm.expectRevert(bytes("limit1 can't be zero if active"));
     harness.validate(config);
   }
 
   function test_validate_withL0L1_withoutTimestape_isNotValid() public {
-    ITradingLimits.Config memory config = configL0L1(0, 1000, 1000, 10000);
+    ITradingLimits.Config memory config = configL0L1(0, 1000, 1000, 1000, 1000, 10000, 10000, 10000);
     vm.expectRevert(bytes("timestep0 can't be zero if active"));
     harness.validate(config);
   }
 
   function test_validate_withL0L1_withLimit0LargerLimit1_isNotValid() public {
-    ITradingLimits.Config memory config = configL0L1(10000, 10000, 1000, 1000);
+    ITradingLimits.Config memory config = configL0L1(10000, 10000, 10000, 10000, 1000, 1000, 1000, 1000);
     vm.expectRevert(bytes("limit1 must be greater than limit0"));
     harness.validate(config);
   }
 
   function test_validate_withLG_withoutLimitGlobal_isNotValid() public {
-    ITradingLimits.Config memory config = configL0L1LG(100, 1000, 1000, 10000, 0);
+    ITradingLimits.Config memory config = configL0L1LG(100, 1000, 1000, 1000, 1000, 10000, 10000, 10000, 0);
     vm.expectRevert(bytes("limitGlobal can't be zero if active"));
     harness.validate(config);
   }
 
   function test_validate_withL0LG_withLimit0LargerLimitGlobal_isNotValid() public {
-    ITradingLimits.Config memory config = configL0LG(10000, 10000, 1000);
+    ITradingLimits.Config memory config = configL0LG(10000, 10000, 10000, 10000, 1000);
     vm.expectRevert(bytes("limitGlobal must be greater than limit0"));
     harness.validate(config);
   }
 
   function test_validate_withL1LG_withLimit1LargerLimitGlobal_isNotValid() public {
-    ITradingLimits.Config memory config = configL0L1LG(100, 1000, 10000, 10000, 1000);
+    ITradingLimits.Config memory config = configL0L1LG(100, 1000, 1000, 1000, 10000, 10000, 10000, 10000, 1000);
     vm.expectRevert(bytes("limitGlobal must be greater than limit1"));
     harness.validate(config);
   }
 
   function test_validate_withL0L1LG_isValid() public view {
-    ITradingLimits.Config memory config = configL0L1LG(100, 1000, 1000, 10000, 100000);
+    ITradingLimits.Config memory config = configL0L1LG(100, 1000, 1000, 1000, 1000, 10000, 10000, 10000, 100000);
     harness.validate(config);
   }
 
   function test_configure_withL1LG_isNotValid() public {
-    ITradingLimits.Config memory config = configL1LG(1000, 10000, 100000);
+    ITradingLimits.Config memory config = configL1LG(1000, 10000, 10000, 10000, 100000);
     vm.expectRevert(bytes("L1 without L0 not allowed"));
     harness.validate(config);
   }
@@ -166,7 +194,7 @@ contract TradingLimitsTest is Test {
   function test_reset_clearsCheckpoints() public {
     state.lastUpdated0 = 123412412;
     state.lastUpdated1 = 123124412;
-    state = harness.reset(state, configL0(500, 1000));
+    state = harness.reset(state, configL0(500, 1000, 1000, 1000));
 
     assertEq(uint256(state.lastUpdated0), 0);
     assertEq(uint256(state.lastUpdated1), 0);
@@ -175,7 +203,7 @@ contract TradingLimitsTest is Test {
   function test_reset_resetsNetflowsOnDisabled() public {
     state.netflow1 = 12312;
     state.netflowGlobal = 12312;
-    state = harness.reset(state, configL0(500, 1000));
+    state = harness.reset(state, configL0(500, 1000, 1000, 1000));
 
     assertEq(state.netflow1, 0);
     assertEq(state.netflowGlobal, 0);
@@ -185,7 +213,7 @@ contract TradingLimitsTest is Test {
     state.netflow0 = 12312;
     state.netflow1 = 12312;
     state.netflowGlobal = 12312;
-    state = harness.reset(state, configL0LG(500, 1000, 100000));
+    state = harness.reset(state, configL0LG(500, 1000, 1000, 1000, 100000));
 
     assertEq(state.netflow0, 12312);
     assertEq(state.netflow1, 0);
@@ -201,36 +229,36 @@ contract TradingLimitsTest is Test {
 
   function test_verify_withL0_butNotMet() public {
     state.netflow0 = 500;
-    harness.verify(state, configL0(500, 1230));
+    harness.verify(state, configL0(500, 1230, 1230, 1230));
   }
 
   function test_verify_withL0_andMetPositively() public {
     state.netflow0 = 1231;
     vm.expectRevert(bytes("L0 Exceeded"));
-    harness.verify(state, configL0(500, 1230));
+    harness.verify(state, configL0(500, 1230, 1230, 1230));
   }
 
   function test_verify_withL0_andMetNegatively() public {
     state.netflow0 = -1231;
     vm.expectRevert(bytes("L0 Exceeded"));
-    harness.verify(state, configL0(500, 1230));
+    harness.verify(state, configL0(500, 1230, 1230, 1230));
   }
 
   function test_verify_withL0L1_butNoneMet() public {
     state.netflow1 = 500;
-    harness.verify(state, configL0L1(50, 100, 500, 1230));
+    harness.verify(state, configL0L1(50, 100, 100, 100, 500, 500, 500, 1230));
   }
 
   function test_verify_withL0L1_andL1MetPositively() public {
     state.netflow1 = 1231;
     vm.expectRevert(bytes("L1 Exceeded"));
-    harness.verify(state, configL0L1(50, 100, 500, 1230));
+    harness.verify(state, configL0L1(50, 100, 100, 100, 500, 500, 500, 1230));
   }
 
   function test_verify_withL0L1_andL1MetNegatively() public {
     state.netflow1 = -1231;
     vm.expectRevert(bytes("L1 Exceeded"));
-    harness.verify(state, configL0L1(50, 100, 500, 1230));
+    harness.verify(state, configL0L1(50, 100, 100, 100, 500, 500, 500, 1230));
   }
 
   function test_verify_withLG_butNoneMet() public {
@@ -260,27 +288,27 @@ contract TradingLimitsTest is Test {
   }
 
   function test_update_withZeroDeltaFlow_doesNotUpdate() public {
-    state = harness.update(state, configL0L1LG(300, 1000, 1 days, 10000, 1000000), 0, 18);
+    state = harness.update(state, configL0L1LG(300, 1000, 1000, 1000, 1 days, 10000, 10000, 10000, 1000000), 0, 18);
     assertEq(state.netflow0, 0);
     assertEq(state.netflow1, 0);
     assertEq(state.netflowGlobal, 0);
   }
 
   function test_update_withL0_updatesActive() public {
-    state = harness.update(state, configL0(500, 1000), 100 * 1e18, 18);
+    state = harness.update(state, configL0(500, 1000, 1000, 1000), 100 * 1e18, 18);
     assertEq(state.netflow0, 100);
     assertEq(state.netflowGlobal, 0);
   }
 
   function test_update_withL0L1_updatesActive() public {
-    state = harness.update(state, configL0L1(500, 1000, 5000, 500000), 100 * 1e18, 18);
+    state = harness.update(state, configL0L1(500, 1000, 1000, 1000, 5000, 500000, 500000, 500000), 100 * 1e18, 18);
     assertEq(state.netflow0, 100);
     assertEq(state.netflow1, 100);
     assertEq(state.netflowGlobal, 0);
   }
 
   function test_update_withL0LG_updatesActive() public {
-    state = harness.update(state, configL0LG(500, 1000, 500000), 100 * 1e18, 18);
+    state = harness.update(state, configL0LG(500, 1000, 1000, 1000, 500000), 100 * 1e18, 18);
     assertEq(state.netflow0, 100);
     assertEq(state.netflow1, 0);
     assertEq(state.netflowGlobal, 100);

--- a/test/unit/swap/Broker.t.sol
+++ b/test/unit/swap/Broker.t.sol
@@ -466,7 +466,7 @@ contract BrokerTest_swap is BrokerTest {
     vm.prank(trader);
     broker.swapIn(address(exchangeProvider), exchangeId, address(stableAsset), address(collateralAsset), 3e20, 0);
     
-    // It increments netFlow1.
+    /// @dev It increments netFlow1.
     for(uint i = 0; i < uint48(config.limit1In / config.limit0In); i ++) {
       skip(config.timestep0 + 1);
       vm.prank(trader);
@@ -474,7 +474,7 @@ contract BrokerTest_swap is BrokerTest {
     }
 
     skip(config.timestep0 + 1);
-    // Here, netFlow1 should exceed Limit1.
+    /// @dev Here, netFlow1 should exceed Limit1 but netFlow0 does not exceed Limit0
     vm.expectRevert(bytes("L1In Exceeded"));
     vm.prank(trader);
     broker.swapIn(address(exchangeProvider), exchangeId, address(stableAsset), address(collateralAsset), 1e20, 0);
@@ -489,7 +489,7 @@ contract BrokerTest_swap is BrokerTest {
     vm.prank(trader);
     broker.swapOut(address(exchangeProvider), exchangeId, address(stableAsset), address(collateralAsset), 3e20, 6e21);   
 
-    // It increments netFlow1.
+    /// @dev It increments netFlow1.
     for(uint i = 0; i < uint48(config.limit1In / config.limit0In); i ++) {
       skip(config.timestep0 + 1);
       vm.prank(trader);
@@ -497,7 +497,7 @@ contract BrokerTest_swap is BrokerTest {
     }
 
     skip(config.timestep0 + 1);
-    // Here, netFlow1 should exceed Limit1.
+    /// @dev Here, netFlow1 should exceed Limit1 but netFlow0 does not exceed Limit0
     vm.expectRevert(bytes("L1In Exceeded"));
     vm.prank(trader);
     broker.swapOut(address(exchangeProvider), exchangeId, address(stableAsset), address(collateralAsset), 4e19, 6e21);
@@ -513,14 +513,14 @@ contract BrokerTest_swap is BrokerTest {
     vm.prank(trader);
     broker.swapIn(address(exchangeProvider), exchangeId, address(collateralAsset), address(stableAsset), 3e20, 0);
 
-    // It increments netFlow1.
+    /// @dev It increments netFlow1.
     for(uint i = 0; i < uint48(config.limit1Out / config.limit0Out); i ++) {
       skip(config.timestep0 + 1);
       vm.prank(trader);
       broker.swapIn(address(exchangeProvider), exchangeId, address(collateralAsset), address(stableAsset), 4e19, 0);
     }
     skip(config.timestep0 + 1);
-    // Here, netFlow1 should exceed Limit1.
+    /// @dev Here, netFlow1 should exceed Limit1 but netFlow0 does not exceed Limit0
     vm.expectRevert("L1Out Exceeded");
     vm.prank(trader);
     broker.swapIn(address(exchangeProvider), exchangeId, address(collateralAsset), address(stableAsset), 4e19, 0);
@@ -535,7 +535,7 @@ contract BrokerTest_swap is BrokerTest {
     vm.prank(trader);
     broker.swapOut(address(exchangeProvider), exchangeId, address(collateralAsset), address(stableAsset), 3e20, 6e21);
     
-    // It increments netFlow1.
+    /// @dev It increments netFlow1.
     for(uint i = 0; i < uint48(config.limit1Out / config.limit0Out); i ++) {
       skip(config.timestep0 + 1);
       vm.prank(trader);
@@ -543,7 +543,7 @@ contract BrokerTest_swap is BrokerTest {
      
     }
     skip(config.timestep0 + 1);
-    // Here, netFlow1 should exceed Limit1.
+    /// @dev Here, netFlow1 should exceed Limit1 but netFlow0 does not exceed Limit0
     vm.expectRevert("L1Out Exceeded");
     vm.prank(trader);
     broker.swapOut(address(exchangeProvider), exchangeId, address(collateralAsset), address(stableAsset), 1e20, 6e21);

--- a/test/unit/swap/Broker.t.sol
+++ b/test/unit/swap/Broker.t.sol
@@ -657,7 +657,6 @@ contract BrokerTest_swap is BrokerTest {
     ITradingLimits.Config memory config;
     config.flags = 1;
     config.timestep0 = 10000;
-    // config.limit0 = 100;
     config.limit0In = 100;
     config.limit0Out = 100;
 
@@ -666,7 +665,7 @@ contract BrokerTest_swap is BrokerTest {
     vm.prank(deployer);
     broker.configureTradingLimit(exchangeId, address(stableAsset), config);
 
-    vm.expectRevert(bytes("L0 Exceeded"));
+    vm.expectRevert(bytes("L0In Exceeded"));
     vm.prank(trader);
     broker.swapIn(address(exchangeProvider), exchangeId, address(stableAsset), address(collateralAsset), 5e20, 0);
   }

--- a/test/unit/swap/Broker.t.sol
+++ b/test/unit/swap/Broker.t.sol
@@ -639,6 +639,8 @@ contract BrokerTest_swap is BrokerTest {
     config.flags = 1;
     config.timestep0 = 10000;
     config.limit0 = 1000;
+    config.limit0In = 1000;
+    config.limit0Out = 1000;
 
     vm.expectEmit(true, true, true, true);
     emit TradingLimitConfigured(exchangeId, address(stableAsset), config);
@@ -656,6 +658,8 @@ contract BrokerTest_swap is BrokerTest {
     config.flags = 1;
     config.timestep0 = 10000;
     config.limit0 = 100;
+    config.limit0In = 100;
+    config.limit0Out = 100;
 
     vm.expectEmit(true, true, true, true);
     emit TradingLimitConfigured(exchangeId, address(stableAsset), config);

--- a/test/unit/swap/Broker.t.sol
+++ b/test/unit/swap/Broker.t.sol
@@ -638,7 +638,6 @@ contract BrokerTest_swap is BrokerTest {
     ITradingLimits.Config memory config;
     config.flags = 1;
     config.timestep0 = 10000;
-    // config.limit0 = 1000;
     config.limit0In = 1000;
     config.limit0Out = 1000;
 

--- a/test/unit/swap/Broker.t.sol
+++ b/test/unit/swap/Broker.t.sol
@@ -456,6 +456,67 @@ contract BrokerTest_swap is BrokerTest {
     broker.swapOut(address(exchangeProvider), exchangeId, address(stableAsset), address(collateralAsset), 1e16, 1e15);
   }
 
+  function test_swap_whenAmountLimitInMet_shouldRevert() public {    
+    ITradingLimits.Config memory config = configureTradeLimit();
+
+    vm.prank(trader);
+    stableAsset.approve(address(broker), type(uint256).max);
+
+    vm.expectRevert(bytes("L0In Exceeded"));
+    vm.prank(trader);
+    broker.swapIn(address(exchangeProvider), exchangeId, address(stableAsset), address(collateralAsset), 3e20, 0);
+    vm.expectRevert(bytes("L0In Exceeded"));
+    vm.prank(trader);
+    broker.swapOut(address(exchangeProvider), exchangeId, address(stableAsset), address(collateralAsset), 3e20, 6e21);   
+
+    for(uint i = 0; i < uint48(config.limit1In / config.limit0In); i ++) {
+      skip(config.timestep0 + 1);
+      vm.prank(trader);
+      broker.swapIn(address(exchangeProvider), exchangeId, address(stableAsset), address(collateralAsset), 5e19, 0);
+      vm.prank(trader);
+      broker.swapOut(address(exchangeProvider), exchangeId, address(stableAsset), address(collateralAsset), 2e19, 6e21);
+     
+    }
+
+    skip(config.timestep0 + 1);
+    vm.expectRevert(bytes("L1In Exceeded"));
+    vm.prank(trader);
+    broker.swapIn(address(exchangeProvider), exchangeId, address(stableAsset), address(collateralAsset), 5e19, 0);
+    vm.expectRevert(bytes("L1In Exceeded"));
+    vm.prank(trader);
+    broker.swapOut(address(exchangeProvider), exchangeId, address(stableAsset), address(collateralAsset), 2e19, 6e21);
+  }
+
+  function test_swap_whenAmountLimitOutMet_shouldRevert() public {    
+    ITradingLimits.Config memory config = configureTradeLimit();
+
+    vm.prank(trader);
+    collateralAsset.approve(address(broker), type(uint256).max);
+
+    vm.expectRevert("L0Out Exceeded");
+    vm.prank(trader);
+    broker.swapOut(address(exchangeProvider), exchangeId, address(collateralAsset), address(stableAsset), 3e20, 6e21);
+    vm.expectRevert("L0Out Exceeded");
+    vm.prank(trader);
+    broker.swapIn(address(exchangeProvider), exchangeId, address(collateralAsset), address(stableAsset), 3e20, 0);
+   
+
+    for(uint i = 0; i < uint48(config.limit1Out / config.limit0Out); i ++) {
+      skip(config.timestep0 + 1);
+      vm.prank(trader);
+      broker.swapIn(address(exchangeProvider), exchangeId, address(collateralAsset), address(stableAsset), 2e19, 0);
+      vm.prank(trader);
+      broker.swapOut(address(exchangeProvider), exchangeId, address(collateralAsset), address(stableAsset), 5e19, 6e21);
+     
+    }
+    skip(config.timestep0 + 1);
+    vm.expectRevert("L1Out Exceeded");
+    vm.prank(trader);
+    broker.swapIn(address(exchangeProvider), exchangeId, address(collateralAsset), address(stableAsset), 2e19, 0);
+    vm.expectRevert("L1Out Exceeded");
+    vm.prank(trader);
+    broker.swapOut(address(exchangeProvider), exchangeId, address(collateralAsset), address(stableAsset), 5e19, 6e21);
+  }
   function test_swapIn_whenTokenInStableAsset_shouldUpdateAndEmit() public {
     uint256 amountIn = 1e16;
     uint256 expectedAmountOut = exchangeProvider.getAmountOut(
@@ -667,5 +728,32 @@ contract BrokerTest_swap is BrokerTest {
     vm.expectRevert(bytes("L0In Exceeded"));
     vm.prank(trader);
     broker.swapIn(address(exchangeProvider), exchangeId, address(stableAsset), address(collateralAsset), 5e20, 0);
+  }
+
+  function configureTradeLimit() public returns (ITradingLimits.Config memory config){
+    config.flags = 3;
+    config.timestep0 = 1_000_000;
+    config.limit0In = 100;
+    config.limit0Out = 100;
+    config.timestep1 = 10_000_000;
+    config.limit1In = 300;
+    config.limit1Out = 500;
+
+    vm.prank(deployer);
+    broker.configureTradingLimit(exchangeId, address(stableAsset), config);
+  }
+  function getTradingLimitsConfig(address tokenAddress) public view returns (ITradingLimits.Config memory config) {
+    bytes32 limitId = getTradingLimitId(tokenAddress);
+    ITradingLimits.Config memory _config;
+    (_config.timestep0, _config.timestep1, _config.limit0In, _config.limit0Out, _config.limit1In, _config.limit1Out, _config.limitGlobal, _config.flags) = Broker(
+      address(broker)
+    ).tradingLimitsConfig(limitId);
+
+    return _config;
+  }
+  function getTradingLimitId(address tokenAddress) public view returns (bytes32 limitId) {
+    bytes32 tokenInBytes32 = bytes32(uint256(uint160(tokenAddress)));
+    bytes32 _limitId = exchangeId ^ tokenInBytes32;
+    return _limitId;
   }
 }

--- a/test/unit/swap/Broker.t.sol
+++ b/test/unit/swap/Broker.t.sol
@@ -638,7 +638,7 @@ contract BrokerTest_swap is BrokerTest {
     ITradingLimits.Config memory config;
     config.flags = 1;
     config.timestep0 = 10000;
-    config.limit0 = 1000;
+    // config.limit0 = 1000;
     config.limit0In = 1000;
     config.limit0Out = 1000;
 
@@ -657,7 +657,7 @@ contract BrokerTest_swap is BrokerTest {
     ITradingLimits.Config memory config;
     config.flags = 1;
     config.timestep0 = 10000;
-    config.limit0 = 100;
+    // config.limit0 = 100;
     config.limit0In = 100;
     config.limit0Out = 100;
 


### PR DESCRIPTION
### Description

Implemented in/out trade limitation values within `Broker`'s `tradingLimitsConfig`(`ITradingLimits.Config`) and added unit test.

### Other changes

_Describe any minor or "drive-by" changes here._

### Tested

It passes all existing unit tests and includes new ones that verify different limitations.

### Related issues

- Fixes #3 

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._

### Documentation

_The set of community facing docs that have been added/modified because of this change_

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Split per-limit configurations into In/Out variants and update trading limit enforcement and tests accordingly across contracts, libraries, scripts, and tests.

### Why are these changes being made?

To enable independent inflow and outflow limits (in/out) for L0 and L1, providing finer-grained control and clearer validation logic; updates align tests and deployment scripts with the new configuration shape and behaviors.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->