### PR TITLE
feat: added fork test actions for non-XDC and XDC chain

### DIFF
--- a/.github/workflows/fork-tests-non-xdc.yaml
+++ b/.github/workflows/fork-tests-non-xdc.yaml
@@ -1,4 +1,4 @@
-name: "ForkTests"
+name: "ForkTests for non-XDC chains"
 
 env:
   FOUNDRY_PROFILE: "fork-tests"

--- a/.github/workflows/fork-tests-non-xdc.yaml
+++ b/.github/workflows/fork-tests-non-xdc.yaml
@@ -1,0 +1,43 @@
+name: "ForkTests"
+
+env:
+  FOUNDRY_PROFILE: "fork-tests"
+  ALFAJORES_RPC_URL: ${{secrets.ALFAJORES_RPC_URL}}
+  CELO_MAINNET_RPC_URL: ${{secrets.CELO_MAINNET_RPC_URL}}
+
+on: 
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"  # everyday at midnight
+
+jobs:
+  test:
+    name: Run fork tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: "recursive"
+          ref: develop
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: "Install Node.js"
+        uses: "actions/setup-node@v3"
+        with:
+          cache: "yarn"
+          node-version: "20"
+
+      - name: "Install the Node.js dependencies"
+        run: "yarn install --immutable"
+
+      - name: "Show the Foundry config"
+        run: "forge config"
+
+      - name: "Run the tests"
+        run: "forge test --no-match-contract XDC"
+
+      - name: "Add test summary"
+        run: |
+          echo "## Tests" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/fork-tests-xdc.yaml
+++ b/.github/workflows/fork-tests-xdc.yaml
@@ -36,7 +36,7 @@ jobs:
         run: "forge config"
 
       - name: "Run the tests"
-        run: "forge test"
+        run: "forge test --match-contract XDC"
 
       - name: "Add test summary"
         run: |

--- a/.github/workflows/fork-tests-xdc.yaml
+++ b/.github/workflows/fork-tests-xdc.yaml
@@ -1,4 +1,4 @@
-name: "ForkTests"
+name: "ForkTests for XDC chain"
 
 env:
   FOUNDRY_PROFILE: "fork-tests"


### PR DESCRIPTION
### Description

added fork test actions for non-XDC and XDC chain

### Other changes

_Describe any minor or "drive-by" changes here._

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._

### Documentation

_The set of community facing docs that have been added/modified because of this change_

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a dedicated fork test workflow for non-XDC chains and adjust the existing XDC fork test workflow to explicitly target XDC contracts.

### Why are these changes being made?

To separate and clearly target tests for non-XDC chains vs XDC chains, ensuring appropriate contract filtering in tests and easier maintenance. The non-XDC workflow runs tests excluding XDC contracts, while the XDC workflow now runs only XDC-contract tests.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->