### PR TITLE
Feat: add large swap(reserve) fork unit test for XDC

### DIFF
--- a/.github/workflows/lint_test.yaml
+++ b/.github/workflows/lint_test.yaml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: "v1.3.1"
 
       - name: Install Node.js
         uses: actions/setup-node@v3
@@ -48,6 +50,9 @@ jobs:
       - name: Show the Foundry config
         run: forge config
 
+      - name: Build the contracts
+        run: forge build
+        
       - name: Run the tests
         run: forge test
 

--- a/test/fork/GoodDollar_XDC/XDC_GoodDollarBaseForkTest.sol
+++ b/test/fork/GoodDollar_XDC/XDC_GoodDollarBaseForkTest.sol
@@ -283,7 +283,7 @@ contract XDC_GoodDollarBaseForkTest is BaseForkTest {
     assertEq(_poolExchange.reserveRatio, _poolExchange.reserveRatio);
     assertEq(_poolExchange.exitContribution, _poolExchange.exitContribution);
   }
-  
+
   function getExchangeId(IBancorExchangeProvider.PoolExchange memory exchange) public view returns (bytes32) {
     return keccak256(abi.encodePacked(IERC20(exchange.reserveAsset).symbol(), IERC20(exchange.tokenAddress).symbol()));
   }

--- a/test/fork/GoodDollar_XDC/XDC_GoodDollarBaseForkTest.sol
+++ b/test/fork/GoodDollar_XDC/XDC_GoodDollarBaseForkTest.sol
@@ -147,7 +147,14 @@ contract XDC_GoodDollarBaseForkTest is BaseForkTest {
     });
 
     vm.prank(AVATAR_ADDRESS);
-    exchangeId = IBancorExchangeProvider(address(goodDollarExchangeProvider)).createExchange(poolExchange);
+    exchangeId = getExchangeId(poolExchange);
+    if (
+      IBancorExchangeProvider(address(goodDollarExchangeProvider)).getPoolExchange(exchangeId).reserveAsset ==
+      address(0)
+    ) {
+      vm.prank(AVATAR_ADDRESS);
+      IBancorExchangeProvider(address(goodDollarExchangeProvider)).createExchange(poolExchange);
+    }
   }
 
   function configureExpansionController() public {
@@ -275,5 +282,9 @@ contract XDC_GoodDollarBaseForkTest is BaseForkTest {
     assertEq(_poolExchange.reserveBalance, _poolExchange.reserveBalance);
     assertEq(_poolExchange.reserveRatio, _poolExchange.reserveRatio);
     assertEq(_poolExchange.exitContribution, _poolExchange.exitContribution);
+  }
+  
+  function getExchangeId(IBancorExchangeProvider.PoolExchange memory exchange) public view returns (bytes32) {
+    return keccak256(abi.encodePacked(IERC20(exchange.reserveAsset).symbol(), IERC20(exchange.tokenAddress).symbol()));
   }
 }

--- a/test/fork/GoodDollar_XDC/XDC_SwapForkTest.sol
+++ b/test/fork/GoodDollar_XDC/XDC_SwapForkTest.sol
@@ -7,6 +7,9 @@ import { TradingLimitHelpers } from "../helpers/TradingLimitHelpers.sol";
 
 // Interfaces
 import { IBancorExchangeProvider } from "contracts/interfaces/IBancorExchangeProvider.sol";
+import { ITradingLimits } from "contracts/interfaces/ITradingLimits.sol";
+import { IERC20 } from "contracts/interfaces/IERC20.sol";
+import { Broker } from "contracts/swap/Broker.sol";
 
 // Contracts
 import { XDC_ID } from "../BaseForkTest.sol";
@@ -64,7 +67,7 @@ contract XDC_GoodDollarSwapForkTest is XDC_GoodDollarBaseForkTest(XDC_ID) {
   }
 
   function test_swapIn_goodDollarToReserveToken() public {
-    uint256 amountIn = 1000 * 1e18;
+    uint256 amountIn = 10000000 * 1e18;
 
     uint256 reserveBalanceBefore = reserveToken.balanceOf(address(goodDollarReserve));
     uint256 priceBefore = IBancorExchangeProvider(address(goodDollarExchangeProvider)).currentPrice(exchangeId);
@@ -159,5 +162,92 @@ contract XDC_GoodDollarSwapForkTest is XDC_GoodDollarBaseForkTest(XDC_ID) {
     assertEq(amountOut, reserveToken.balanceOf(trader));
     assertEq(reserveBalanceBefore - amountOut, reserveBalanceAfter);
     assertTrue(priceAfter < priceBefore);
+  }
+  function test_swapIn_large_goodDollarToReserveToken() public {
+    // uint256 amountIn = 30000000 * 1e18;
+    _disableTradeLimits();
+    uint256 amountIn = IERC20(address(goodDollarToken)).totalSupply() * 9 / 10;
+
+    uint256 reserveBalanceBefore = reserveToken.balanceOf(address(goodDollarReserve));
+    uint256 priceBefore = IBancorExchangeProvider(address(goodDollarExchangeProvider)).currentPrice(exchangeId);
+    uint256 expectedAmountOut = broker.getAmountOut(
+      address(goodDollarExchangeProvider),
+      exchangeId,
+      address(goodDollarToken),
+      address(reserveToken),
+      amountIn
+    );
+
+    mintGoodDollar(amountIn, trader);
+
+    vm.startPrank(trader);
+    goodDollarToken.approve(address(broker), amountIn);
+    broker.swapIn(
+      address(goodDollarExchangeProvider),
+      exchangeId,
+      address(goodDollarToken),
+      address(reserveToken),
+      amountIn,
+      expectedAmountOut
+    );
+    uint256 priceAfter = IBancorExchangeProvider(address(goodDollarExchangeProvider)).currentPrice(exchangeId);
+    uint256 reserveBalanceAfter = reserveToken.balanceOf(address(goodDollarReserve));
+
+    assertEq(expectedAmountOut, reserveToken.balanceOf(trader));
+    assertEq(reserveBalanceBefore - expectedAmountOut, reserveBalanceAfter);
+    assertTrue(priceAfter < priceBefore);
+    assertTrue(priceAfter > 0);
+  }
+
+  function test_swapOut_large_goodDollarToReserveToken() public {
+    // uint256 amountOut = 5000 * 1e6;
+    _disableTradeLimits();
+    uint256 amountOut = reserveToken.balanceOf(address(goodDollarReserve)) * 9 / 10;
+
+    uint256 reserveBalanceBefore = reserveToken.balanceOf(address(goodDollarReserve));
+    uint256 priceBefore = IBancorExchangeProvider(address(goodDollarExchangeProvider)).currentPrice(exchangeId);
+    uint256 expectedAmountIn = broker.getAmountIn(
+      address(goodDollarExchangeProvider),
+      exchangeId,
+      address(goodDollarToken),
+      address(reserveToken),
+      amountOut
+    );
+
+    mintGoodDollar(expectedAmountIn, trader);
+
+    vm.startPrank(trader);
+    goodDollarToken.approve(address(broker), expectedAmountIn);
+    broker.swapOut(
+      address(goodDollarExchangeProvider),
+      exchangeId,
+      address(goodDollarToken),
+      address(reserveToken),
+      amountOut,
+      expectedAmountIn
+    );
+    uint256 priceAfter = IBancorExchangeProvider(address(goodDollarExchangeProvider)).currentPrice(exchangeId);
+    uint256 reserveBalanceAfter = reserveToken.balanceOf(address(goodDollarReserve));
+
+    assertEq(amountOut, reserveToken.balanceOf(trader));
+    assertEq(reserveBalanceBefore - amountOut, reserveBalanceAfter);
+    assertTrue(priceAfter < priceBefore);
+    assertTrue(priceAfter > 0);
+  }
+
+  function _disableTradeLimits() internal {
+    ITradingLimits.Config memory cusdLimits1 = ITradingLimits.Config({
+      timestep0: 7 days,
+      timestep1: 30 days,
+      limit0In: 0,
+      limit0Out: 0,
+      limit1In: 0,
+      limit1Out: 0,
+      limitGlobal: 0,
+      flags: 0x00 
+    });
+    bytes32 exchangeId = keccak256(abi.encodePacked(IERC20(address(reserveToken)).symbol(), IERC20(address(goodDollarToken)).symbol()));
+    vm.prank(Broker(address(broker)).owner());
+    broker.configureTradingLimit(exchangeId, address(reserveToken), cusdLimits1);
   }
 }

--- a/test/fork/GoodDollar_XDC/XDC_SwapForkTest.sol
+++ b/test/fork/GoodDollar_XDC/XDC_SwapForkTest.sol
@@ -166,7 +166,7 @@ contract XDC_GoodDollarSwapForkTest is XDC_GoodDollarBaseForkTest(XDC_ID) {
   function test_swapIn_large_goodDollarToReserveToken() public {
     // uint256 amountIn = 30000000 * 1e18;
     _disableTradeLimits();
-    uint256 amountIn = IERC20(address(goodDollarToken)).totalSupply() * 9 / 10;
+    uint256 amountIn = (IERC20(address(goodDollarToken)).totalSupply() * 9) / 10;
 
     uint256 reserveBalanceBefore = reserveToken.balanceOf(address(goodDollarReserve));
     uint256 priceBefore = IBancorExchangeProvider(address(goodDollarExchangeProvider)).currentPrice(exchangeId);
@@ -202,7 +202,7 @@ contract XDC_GoodDollarSwapForkTest is XDC_GoodDollarBaseForkTest(XDC_ID) {
   function test_swapOut_large_goodDollarToReserveToken() public {
     // uint256 amountOut = 5000 * 1e6;
     _disableTradeLimits();
-    uint256 amountOut = reserveToken.balanceOf(address(goodDollarReserve)) * 9 / 10;
+    uint256 amountOut = (reserveToken.balanceOf(address(goodDollarReserve)) * 9) / 10;
 
     uint256 reserveBalanceBefore = reserveToken.balanceOf(address(goodDollarReserve));
     uint256 priceBefore = IBancorExchangeProvider(address(goodDollarExchangeProvider)).currentPrice(exchangeId);
@@ -244,9 +244,11 @@ contract XDC_GoodDollarSwapForkTest is XDC_GoodDollarBaseForkTest(XDC_ID) {
       limit1In: 0,
       limit1Out: 0,
       limitGlobal: 0,
-      flags: 0x00 
+      flags: 0x00
     });
-    bytes32 exchangeId = keccak256(abi.encodePacked(IERC20(address(reserveToken)).symbol(), IERC20(address(goodDollarToken)).symbol()));
+    bytes32 exchangeId = keccak256(
+      abi.encodePacked(IERC20(address(reserveToken)).symbol(), IERC20(address(goodDollarToken)).symbol())
+    );
     vm.prank(Broker(address(broker)).owner());
     broker.configureTradingLimit(exchangeId, address(reserveToken), cusdLimits1);
   }


### PR DESCRIPTION
### Description

added large swap (selling gooddolar for reserveToken against reserve) fork unit test  

### Other changes

add check to verify if exchange already exists

### Tested

tests passed on forked XDC network

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._

### Documentation

_The set of community facing docs that have been added/modified because of this change_

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Enable and validate large-scale swap (reserve) functionality on XDC fork by enhancing fork tests, adding a helper to derive exchange IDs, conditionally creating exchanges, and introducing large In/Out swap scenarios, plus CI workflow and test build steps.

### Why are these changes being made?
To robustly verify large swap paths and price dynamics on XDC forks, and to ensure the tests reflect real-world large trades; the changes also improve test reliability by deriving exchange IDs deterministically, creating missing exchanges when needed, and disabling trade limits for stress tests.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->