### PR TITLE
fix: added missing build step in lint github action

### DIFF
--- a/.github/workflows/lint_test.yaml
+++ b/.github/workflows/lint_test.yaml
@@ -48,6 +48,9 @@ jobs:
       - name: Show the Foundry config
         run: forge config
 
+      - name: Build the contracts
+        run: forge build --force
+
       - name: Run the tests
         run: forge test
 

--- a/.github/workflows/lint_test.yaml
+++ b/.github/workflows/lint_test.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: stable
+          version: "v1.3.1"
 
       - name: Install Node.js
         uses: actions/setup-node@v3
@@ -49,6 +49,9 @@ jobs:
 
       - name: Show the Foundry config
         run: forge config
+
+      - name: Build the contracts
+        run: forge build
 
       - name: Run the tests
         run: forge test

--- a/.github/workflows/lint_test.yaml
+++ b/.github/workflows/lint_test.yaml
@@ -50,9 +50,6 @@ jobs:
       - name: Show the Foundry config
         run: forge config
 
-      - name: Build the contracts
-        run: forge build --skip test
-
       - name: Run the tests
         run: forge test
 

--- a/.github/workflows/lint_test.yaml
+++ b/.github/workflows/lint_test.yaml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
 
       - name: Install Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/lint_test.yaml
+++ b/.github/workflows/lint_test.yaml
@@ -51,7 +51,7 @@ jobs:
         run: forge config
 
       - name: Build the contracts
-        run: forge build
+        run: forge build --skip test
 
       - name: Run the tests
         run: forge test

--- a/.github/workflows/lint_test.yaml
+++ b/.github/workflows/lint_test.yaml
@@ -49,7 +49,7 @@ jobs:
         run: forge config
 
       - name: Build the contracts
-        run: forge build --force
+        run: forge build
 
       - name: Run the tests
         run: forge test


### PR DESCRIPTION
### Description

added missing build step in lint github action because some contracts in Celo(they are imported in import.sol) are not compiled and it causes test failure.

### Other changes

_Describe any minor or "drive-by" changes here._

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._

### Documentation

_The set of community facing docs that have been added/modified because of this change_

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Build the contracts by running forge build --force in the lint_test workflow.

### Why are these changes being made?
This ensures artifacts are generated before tests run and prevents failures due to missing builds.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->